### PR TITLE
Zero's and NA's removed from lifetable

### DIFF
--- a/R/0_lifetableAndActuarialtableClassesAndMethods.R
+++ b/R/0_lifetableAndActuarialtableClassesAndMethods.R
@@ -30,18 +30,26 @@ setClass("actuarialtable",
 
 #METHODS DEFINITIONS
 
+#constructor for lifetable object
+lifetable <- function(x = 0:3, lx = c(100,90, 50, 10), name = "Generic life table") {
+  if(length(x) != length(lx)) stop("length of x and lx must be equal")
+  
+  posToRemove <- which(lx %in% c(0,NA))
+  if(length(posToRemove) > 0) {
+    x <- x[-posToRemove]
+    lx <- lx[-posToRemove]
+  }
+  
+  out <- new("lifetable", x = x, lx = lx, name = name)
+  return(out)
+}
+
 #validity method for lifetable object
 setValidity("lifetable",
 		function(object) {
 			check<-NULL
 			if(length(object@x)!=length(object@lx)) check<-"Error! x and lx does not match" #checks length of the obj
 			if(any(diff(object@lx)>0)) check<-"Error! population at risk not decrementing" #check coherence of life table
-			if(any(object@lx %in% c(0,NA))) {
-				cat("removing NA and 0s") #removes na
-				posToRemove=which(object@lx %in% c(0,NA))
-				object@x=object@x[-posToRemove]
-				object@lx=object@lx[-posToRemove]
-			}
 			if(is.null(check)) return(TRUE) else 
 				return(check)
 		}

--- a/tests/testthat/testObjectInitialization.R
+++ b/tests/testthat/testObjectInitialization.R
@@ -1,0 +1,30 @@
+library(lifecontingencies)
+
+context("Object Initialization")
+
+
+
+test_that("Zeros and NAs in lx are removed", {
+  x <- 0:4
+
+  lx <- c(100, 75, 50, 25, 0)
+  tbl <- lifetable(x = x, lx = lx)
+  expect_equal(tbl@x, c(0, 1, 2, 3))
+  expect_equal(tbl@lx, c(100, 75, 50, 25))
+  
+  lx <- c(100, NA, 50, 25, 12)
+  tbl <- lifetable(x = x, lx = lx)
+  expect_equal(tbl@x, c(0, 2, 3, 4))
+  expect_equal(tbl@lx, c(100, 50, 25, 12))
+  
+  lx <- c(100, NA, 50, 25, 0)
+  tbl <- lifetable(x = x, lx = lx)
+  expect_equal(tbl@x, c(0, 2, 3))
+  expect_equal(tbl@lx, c(100, 50, 25))
+
+  lx <- c(100, NA, 50, NA, 0)
+  tbl <- lifetable(x = x, lx = lx)
+  expect_equal(tbl@x, c(0, 2))
+  expect_equal(tbl@lx, c(100, 50))
+  
+})


### PR DESCRIPTION
Dear Giorgio,

thank you so much for the life contingencies package.  I've noticed a few things and I'll be sending you some pull requests for your consideration.

The code inside the validity method for lifetable to remove zero's and
NA's does not have the intended effect (they are not removed from the object).

Created a constructor method to remove 0's and NA's and removed the code
from the validity method.

Added test file for object initialization to check the removal of NA's
and 0's.

Best regards,

Ernesto Schirmacher