### PR TITLE
Fix calculation of n in Axn and pxt at end of life table

### DIFF
--- a/R/3_demographicFunctions.R
+++ b/R/3_demographicFunctions.R
@@ -82,37 +82,57 @@ pxt <- function(object, x, t, fractional = "linear", decrement)
   #  out <- 1 / object@lx[which(object@x == x)]
   #} else {
     #before x+t>=omega
-    if ((x + t) > omega)
-      out <- 0
-    else
-      #fractional ages
-    {
-      if ((t %% 1) == 0)
+    if ((x + t) >= omega + 1)
+      return(0)
+
+  if((x + t) > omega){ # x + t is between last lx > 0 and 0
+
+    z <- t %% 1 #the fraction of year
+    #linearly interpolates if fractional age
+    pl <-
+      object@lx[which(object@x == floor(t + x))] / object@lx[which(object@x ==
+                                                                     x)] # Kevin Owens: fix on this line, moving it out of the linear if statement so it can be used in other assumptions
+    if (fractional == "linear") {
+      ph <- 0
+      out <- z * ph + (1 - z) * pl
+    } else if (fractional == "constant force") {
+      out <- pl * pxt(object = object, x = (x + floor(t)),t = 1) ^ z # fix on this line
+    } else if (fractional == "hyperbolic") {
+      out <-
+        pl * pxt(object = object, x = (x + floor(t)),t = 1) / (1 - (1 - z) * qxt(
+          object = object, x = (x + floor(t)),t = 1
+        )) # Kevin Owens: fix on this line
+    }
+  }
+  else # x + t is less that or equal to omega
+    #fractional ages
+  {
+    if ((t %% 1) == 0)
+      out <-
+        object@lx[which(object@x == t + x)] / object@lx[which(object@x == x)]
+    else {
+      z <- t %% 1 #the fraction of year
+      #linearly interpolates if fractional age
+      pl <-
+        object@lx[which(object@x == floor(t + x))] / object@lx[which(object@x ==
+                                                                       x)] # Kevin Owens: fix on this line, moving it out of the linear if statement so it can be used in other assumptions
+      if (fractional == "linear") {
+        ph <-
+          object@lx[which(object@x == ceiling(t + x))] / object@lx[which(object@x ==
+                                                                           x)]
+        out <- z * ph + (1 - z) * pl
+      } else if (fractional == "constant force") {
+        out <- pl * pxt(object = object, x = (x + floor(t)),t = 1) ^ z # fix on this line
+      } else if (fractional == "hyperbolic") {
         out <-
-          object@lx[which(object@x == t + x)] / object@lx[which(object@x == x)]
-      else {
-        z <- t %% 1 #the fraction of year
-        #linearly interpolates if fractional age
-        pl <-
-          object@lx[which(object@x == floor(t + x))] / object@lx[which(object@x ==
-                                                                         x)] # Kevin Owens: fix on this line, moving it out of the linear if statement so it can be used in other assumptions
-        if (fractional == "linear") {
-          ph <-
-            object@lx[which(object@x == ceiling(t + x))] / object@lx[which(object@x ==
-                                                                             x)]
-          out <- z * ph + (1 - z) * pl
-        } else if (fractional == "constant force") {
-          out <- pl * pxt(object = object, x = (x + floor(t)),t = 1) ^ z # fix on this line
-        } else if (fractional == "hyperbolic") {
-          out <-
-            pl * pxt(object = object, x = (x + floor(t)),t = 1) / (1 - (1 - z) * qxt(
-              object = object, x = (x + floor(t)),t = 1
-            )) # Kevin Owens: fix on this line
-        }
+          pl * pxt(object = object, x = (x + floor(t)),t = 1) / (1 - (1 - z) * qxt(
+            object = object, x = (x + floor(t)),t = 1
+          )) # Kevin Owens: fix on this line
       }
     }
-    
-#  }
+  }
+
+  #  }
   return(out)
 }
 

--- a/R/5_actuarialFunctions.R
+++ b/R/5_actuarialFunctions.R
@@ -250,7 +250,7 @@ Axn <-
     if (missing(m))
       m <- 0
     if (missing(n))
-      n <- getOmega(actuarialtable) - x - m - 1
+      n <- getOmega(actuarialtable)+1 - x - m
 #       n = getOmega(actuarialtable) - x - m + 1 #Rosa patch
     if (n == 0)
       return(0)

--- a/tests/testthat/testActuarialMathematics.R
+++ b/tests/testthat/testActuarialMathematics.R
@@ -22,10 +22,10 @@ test_that("Single life annuities are calculated correctly", {
   lx <- seq(100, 10, by = -10)
   tbl <- new("actuarialtable", x = x, lx = lx, interest = 0.04, name = "Linear table")
   v <- (1 + 0.04)^(-1)
-  
+
   ans <- sum((lx[6:10] * v^(0:4))/lx[6])
   expect_equal(axn(tbl, x = 5), ans)
-  
+
   ans <- sum((lx[6:8] * v^(0:2))/lx[6])
   expect_equal(axn(tbl, x = 5, n = 3), ans)
 })
@@ -34,7 +34,7 @@ test_that("axn and axyzn return equal values for single mortality table", {
   x <- 0:9
   lx <- seq(100, 10, by = -10)
   tbl <- new("actuarialtable", x = x, lx = lx, interest = 0.04, name = "Linear table")
-  
+
   expect_equal(axn(tbl, x = 5, n = 1), axyzn(list(tbl), x = 5, n = 1))
   expect_equal(axn(tbl, x = 5, n = 2), axyzn(list(tbl), x = 5, n = 2))
   expect_equal(axn(tbl, x = 5, n = 3), axyzn(list(tbl), x = 5, n = 3))
@@ -42,7 +42,7 @@ test_that("axn and axyzn return equal values for single mortality table", {
   expect_equal(axn(tbl, x = 5, n = 5), axyzn(list(tbl), x = 5, n = 5))
   expect_equal(axn(tbl, x = 5, n = 6), axyzn(list(tbl), x = 5, n = 6))
   expect_equal(axn(tbl, x = 5), axyzn(list(tbl), x = 5))
-  
+
   expect_equal(axn(tbl, x = 0), axyzn(list(tbl), x = 0))
   expect_equal(axn(tbl, x = 1), axyzn(list(tbl), x = 1))
   expect_equal(axn(tbl, x = 2), axyzn(list(tbl), x = 2))
@@ -74,9 +74,36 @@ test_that("Example from Wolfgang Abele on April 27, 2015",{
           33755.47658,26522.3193,20688.28429,16029.96538)
   male <- new("actuarialtable", x = 0:111, lx = lx, interest = 0.04, name = "Males")
   female <- new("actuarialtable", x = 0:111, lx = ly, interest = 0.04, name = "Females")
-  
+
   expect_equal(axn(male, x = 100) + axn(female, x = 102) - 
                  axyzn(list(male, female), x = c(100, 102), status = "joint"), 
                axyzn(list(male, female), x = c(100, 102), status = "last"))
-  
+})
+
+test_that("Life insurance with uniformly decreasing population at risk", {
+  x <- 0:9
+  lx <- seq(100, 10, by = -10)
+  tbl <- new("actuarialtable", x = x, lx = lx, interest = 0, name = "Uniformly decreasing lx")
+
+  expect_equal(Axn(tbl, x = 0), 1)
+  expect_equal(Axn(tbl, x = 1), 1)
+  expect_equal(Axn(tbl, x = 2), 1)
+  expect_equal(Axn(tbl, x = 3), 1)
+  expect_equal(Axn(tbl, x = 4), 1)
+  expect_equal(Axn(tbl, x = 5), 1)
+  expect_equal(Axn(tbl, x = 6), 1)
+  expect_equal(Axn(tbl, x = 7), 1)
+  expect_equal(Axn(tbl, x = 8), 1)
+  expect_equal(Axn(tbl, x = 9), 1)
+
+  expect_equal(Axn(tbl, x = 7.0, k = 2), 1)
+  expect_equal(Axn(tbl, x = 3.0, k = 2), 1)
+  expect_equal(Axn(tbl, x = 3.5, k = 2), 1)
+
+  pmts <- rep(1,6)
+  time <- seq(0.5, 3.0, by = 0.5)
+  prob <- rep(5/30, 6)
+  disc <- (1.06)^(-time)
+  ans  <- sum(pmts * disc * prob)
+  expect_equal(Axn(tbl, x = 7, k = 2, i = 0.06), ans)
 })

--- a/tests/testthat/testDemography.R
+++ b/tests/testthat/testDemography.R
@@ -16,11 +16,11 @@ test_that("qx and mx", {
 test_that("Survival probabilities are correct in simple uniform mortality table",{
   l <- function(x) return(max(0, 100 - 10 * x))
   f <- function(x, t) return(l(x+t)/l(x))
-  
+
   x <- 0:9
   lx <- seq(100, 10, by = -10)
   tbl <- new("lifetable",x = x, lx = lx, name = "Uniform mortality")
-  
+
   expect_equal(pxt(tbl, x = 0, t = 2.4), f(0,2.4))
   expect_equal(pxt(tbl, x = 7, t = 0), f(7,0))
   expect_equal(pxt(tbl, x = 7, t = 1.9), f(7,1.9))
@@ -30,7 +30,7 @@ test_that("pxt and pxyzt return equal results for a single table", {
   x <- 0:9
   lx <- seq(100, 10, by = -10)
   tbl <- new("lifetable",x = x, lx = lx, name = "Uniform mortality")
-  
+
   expect_equal(pxt(tbl, x = 5, t = 3.1), pxyzt(list(tbl), x = c(5), t = c(3.1)))
   expect_equal(pxt(tbl, x = 1, t = 3.1), pxyzt(list(tbl), x = c(1), t = c(3.1)))
   expect_equal(pxt(tbl, x = 2.4, t = 5.3), pxyzt(list(tbl), x = c(2.4), t = c(5.3)))

--- a/tests/testthat/testDemography.R
+++ b/tests/testthat/testDemography.R
@@ -35,3 +35,16 @@ test_that("pxt and pxyzt return equal results for a single table", {
   expect_equal(pxt(tbl, x = 1, t = 3.1), pxyzt(list(tbl), x = c(1), t = c(3.1)))
   expect_equal(pxt(tbl, x = 2.4, t = 5.3), pxyzt(list(tbl), x = c(2.4), t = c(5.3)))
 })
+
+test_that("Probability of death within various intervals", {
+  x <- 0:9
+  lx <- seq(100, 10, by = -10)
+  tbl <- new("lifetable",x = x, lx = lx, name = "Uniform mortality")
+
+  expect_equal(pxt(tbl, x = 7, t = 0.0) * qxt(tbl, x = 7.0, t = 0.5), 5/30)
+  expect_equal(pxt(tbl, x = 7, t = 0.5) * qxt(tbl, x = 7.5, t = 0.5), 5/30)
+  expect_equal(pxt(tbl, x = 7, t = 1.0) * qxt(tbl, x = 8.0, t = 0.5), 5/30)
+  expect_equal(pxt(tbl, x = 7, t = 1.5) * qxt(tbl, x = 8.5, t = 0.5), 5/30)
+  expect_equal(pxt(tbl, x = 7, t = 2.0) * qxt(tbl, x = 9.0, t = 0.5), 5/30)
+  expect_equal(pxt(tbl, x = 7, t = 2.5) * qxt(tbl, x = 9.5, t = 0.5), 5/30)
+})


### PR DESCRIPTION
Function Axn was not calculating correctly because it was ignoring the last
terms in the summation.  I fixed n but then noticed that for fractional periods
(with k > 1) and interest rate equal to zero Axn was not returning a value of 1.

The root cause was the calculation of pxt when x + t was in the range
[omega, omega+1]. Under linear interpolation in this interval we should still
get positive probabilities of death.

With the following mortality table
`
x <- 0:9;
lx <- seq(100, 10, by = -10);
tbl <- new("actuarialtable", x = x, lx = lx, interest = 0, name = "Uniform");
`

the calculation of `Axn(tbl, x = 7, k = 2)` should return the value 1.  In this case
there should be 6 intervals with positive probability (each equal to 5/30).

Added tests to both pxt and Axn.