### PR TITLE
Fix calculation of n in Axn and axn

### DIFF
--- a/R/5_actuarialFunctions.R
+++ b/R/5_actuarialFunctions.R
@@ -250,7 +250,7 @@ Axn <-
     if (missing(m))
       m <- 0
     if (missing(n))
-      n <- getOmega(actuarialtable)+1 - x - m
+      n <- ceiling((getOmega(actuarialtable)+1 - x - m) * k) / k  # want n to be a multiple of 1/k
 #       n = getOmega(actuarialtable) - x - m + 1 #Rosa patch
     if (n == 0)
       return(0)

--- a/R/5_actuarialFunctions.R
+++ b/R/5_actuarialFunctions.R
@@ -48,7 +48,7 @@ axn <-
     if (missing(m))
       m = 0
     if (missing(n))
-      n = getOmega(actuarialtable) + 1 - x - m #n=getOmega(actuarialtable)-x-m Patch by Reinhold
+      n = ceiling((getOmega(actuarialtable) + 1 - x - m) * k) / k #n=getOmega(actuarialtable)-x-m Patch by Reinhold
     if (n == 0) {
       out = 0
       return(out)

--- a/R/5_actuarialFunctions.R
+++ b/R/5_actuarialFunctions.R
@@ -171,7 +171,7 @@ axyzn <-
       n = 0
       for (j in 1:numTables)
         n = (max(n,(getOmega(tablesList[[j]]) - x[j])))
-      n = n+1 - m
+      n = ceiling((n+1 - m)*k)/k
       #n=n-m-1 patch by Reinhold
     }
     

--- a/tests/testthat/testActuarialMathematics.R
+++ b/tests/testthat/testActuarialMathematics.R
@@ -46,6 +46,11 @@ test_that("axn and axyzn return equal values for single mortality table", {
   expect_equal(axn(tbl, x = 0), axyzn(list(tbl), x = 0))
   expect_equal(axn(tbl, x = 1), axyzn(list(tbl), x = 1))
   expect_equal(axn(tbl, x = 2), axyzn(list(tbl), x = 2))
+
+  expect_equal(axn(tbl, x = 6.2, k = 4), axyzn(list(tbl), x = 6.2, k = 4))
+  expect_equal(axn(tbl, x = 6.9, k = 4), axyzn(list(tbl), x = 6.9, k = 4))
+  expect_equal(axn(tbl, x = 7.3, k = 2), axyzn(list(tbl), x = 7.3, k = 2))
+  expect_equal(axn(tbl, x = 8.7, k = 2), axyzn(list(tbl), x = 8.7, k = 2))
 })
 
 test_that("Example from Wolfgang Abele on April 27, 2015",{

--- a/tests/testthat/testActuarialMathematics.R
+++ b/tests/testthat/testActuarialMathematics.R
@@ -107,3 +107,22 @@ test_that("Life insurance with uniformly decreasing population at risk", {
   ans  <- sum(pmts * disc * prob)
   expect_equal(Axn(tbl, x = 7, k = 2, i = 0.06), ans)
 })
+
+test_that("Whole life insurance with fractional starting age", {
+  x <- 0:9
+  lx <- seq(100, 10, by = -10)
+  tbl <- new("actuarialtable", x = x, lx = lx, interest = 0, name = "Uniformly decreasing lx")
+
+  expect_equal(Axn(tbl, x = 8.3, k = 2), 1)
+  expect_equal(Axn(tbl, x = 8.7, k = 2), 1)
+
+  v <- 1.06^(-seq(0.5, 2.0, by = 0.5))
+  p <- c(rep(5/17,3), 2/17)
+  ans <- sum(p * v)
+  expect_equal(Axn(tbl, x = 8.3, k = 2, i = 0.06), ans)
+
+  v <- 1.06^(-seq(0.5, 1.5, by = 0.5))
+  p <- c(rep(5/13,2), 3/13)
+  ans <- sum(p * v)
+  expect_equal(Axn(tbl, x = 8.7, k = 2, i = 0.06), ans)
+})

--- a/tests/testthat/testActuarialMathematics.R
+++ b/tests/testthat/testActuarialMathematics.R
@@ -126,3 +126,35 @@ test_that("Whole life insurance with fractional starting age", {
   ans <- sum(p * v)
   expect_equal(Axn(tbl, x = 8.7, k = 2, i = 0.06), ans)
 })
+
+test_that("Annuities with fractional starting age and k > 1", {
+  x <- 0:9
+  lx <- seq(100, 10, by = -10)
+  tbl <- new("actuarialtable", x = x, lx = lx, interest = 0.04, name = "Uniformly decreasing lx")
+
+  v <- 1.04^(-seq(0, 3.75, by = 0.25))
+  p <- (100 - 10 * seq(6.2, 9.95, by = 0.25))/38
+  ans <- sum(v * p)/4
+  expect_equal(axn(tbl, x = 6.2, k = 4), ans)
+
+  v <- 1.04^(-seq(0, 2, by = 0.25))
+  p <- (100 - 10 * seq(7.9, 9.9, by = 0.25))/21
+  ans <- sum(v * p)/4
+  expect_equal(axn(tbl, x = 7.9, k = 4), ans)
+})
+
+test_that("Annuities with fractional age x, k > 1, and m > 0", {
+  x <- 0:9
+  lx <- seq(100, 10, by = -10)
+  tbl <- new("actuarialtable", x = x, lx = lx, interest = 0.04, name = "Uniformly decreasing lx")
+
+  v <- 1.04^(-(0.6+seq(0, by = 0.25, length = 13)))
+  p <- (100 - 10 * seq(6.8, 9.80, by = 0.25))/38
+  ans <- sum(v * p)/4
+  expect_equal(axn(tbl, x = 6.2, k = 4, m = 0.6), ans)
+
+  v <- 1.04^(-(1.4+seq(0, 0.5, by = 0.25)))
+  p <- (100 - 10 * seq(9.3, 9.8, by = 0.25))/21
+  ans <- sum(v * p)/4
+  expect_equal(axn(tbl, x = 7.9, k = 4, m = 1.4), ans)
+})


### PR DESCRIPTION
Fix the calculation of `n` when this parameter is missing.  The value of `n` must be
an integer multiple of `1/k`.

With the original definition of `n` there were cases when function `Axn` with zero interest
rate would **not** return a value of 1!  For example, `Axn(tbl, x = 6.2, k = 2, i = 0)`.

The root cause of the problem was that in calculating the times, probabilities, and cashflows 
the last entry was short of omega + 1, and thus we were missing an interval where a person
could die at the very end of the life table.

I believe this fixes issue #2 from Christophe Dutang.