### PR TITLE
Harden and regression-test Rcpp backend

### DIFF
--- a/src/lifecontingenciesRcpp.cpp
+++ b/src/lifecontingenciesRcpp.cpp
@@ -74,16 +74,19 @@ double presentValueC(NumericVector cashFlows,
   R_xlen_t n = cashFlows.size();
 
   for (R_xlen_t i = 0; i < n; ++i) {
-    double discountFactor = std::pow(1.0 + interestRates[i], -timeIds[i]);
-
-    // power = 1 is by far the common case for present values.  Avoid the
-    // second pow() call while preserving the original R calculation exactly
-    // at the level of its mathematical operations.
     if (power == 1.0) {
+      // Common case: avoid the second pow() entirely.
+      double discountFactor =
+        std::pow(1.0 + interestRates[i], -timeIds[i]);
       total += cashFlows[i] * discountFactor * probabilities[i];
     } else {
+      // Algebraically combine the two discounting powers into one pow().
+      // This reduces the expensive power evaluations from two to one while
+      // preserving the same mathematical expression.
+      double discountFactor =
+        std::pow(1.0 + interestRates[i], -timeIds[i] * power);
       double term = std::pow(cashFlows[i], power) *
-        std::pow(discountFactor, power) * probabilities[i];
+        discountFactor * probabilities[i];
       total += term;
     }
   }

--- a/src/lifecontingenciesRcpp.cpp
+++ b/src/lifecontingenciesRcpp.cpp
@@ -1,17 +1,45 @@
 #include <Rcpp.h>
-#include <math.h> 
+#include <cmath>
+
 using namespace Rcpp;
 
+namespace {
+
+inline void check_same_length(const NumericVector& x,
+                              const NumericVector& y,
+                              const char* message) {
+  if (x.size() != y.size()) {
+    stop(message);
+  }
+}
+
+inline void check_same_length(const NumericVector& x,
+                              const NumericVector& y,
+                              const NumericVector& z,
+                              const char* message) {
+  if (x.size() != y.size() || x.size() != z.size()) {
+    stop(message);
+  }
+}
+
+inline void check_positive_frequency(double k) {
+  if (!std::isfinite(k) || k <= 0.0) {
+    stop("k must be a finite positive number");
+  }
+}
+
+} // namespace
 
 // [[Rcpp::export(name=".mult3sum")]]
 double mult3sum(NumericVector x, NumericVector y, NumericVector z)
 {
-  double total=0;
-  // assuming x y z have the same length
-  int n = x.size();
+  check_same_length(x, y, z, "x, y and z must have the same length");
 
-  for(int i = 0; i < n; ++i) {
-    total += x[i]*y[i]*z[i];
+  double total = 0.0;
+  R_xlen_t n = x.size();
+
+  for (R_xlen_t i = 0; i < n; ++i) {
+    total += x[i] * y[i] * z[i];
   }
   return total;
 }
@@ -19,12 +47,13 @@ double mult3sum(NumericVector x, NumericVector y, NumericVector z)
 // [[Rcpp::export(name=".mult2sum")]]
 double mult2sum(NumericVector x, NumericVector y)
 {
-  double total=0;
-  // assuming x y z have the same length
-  int n = x.size();
+  check_same_length(x, y, "x and y must have the same length");
 
-  for(int i = 0; i < n; ++i) {
-    total += x[i]*y[i];
+  double total = 0.0;
+  R_xlen_t n = x.size();
+
+  for (R_xlen_t i = 0; i < n; ++i) {
+    total += x[i] * y[i];
   }
   return total;
 }
@@ -35,77 +64,84 @@ double presentValueC(NumericVector cashFlows,
                      NumericVector interestRates,
                      NumericVector probabilities,
                      double power = 1.0) {
-  int n = cashFlows.size();
-  double total = 0.0;
+  if (cashFlows.size() != timeIds.size() ||
+      cashFlows.size() != interestRates.size() ||
+      cashFlows.size() != probabilities.size()) {
+    stop("cashFlows, timeIds, interestRates and probabilities must have the same length");
+  }
 
-  for (int i = 0; i < n; ++i) {
-    double discountFactor = pow(1.0 + interestRates[i], -timeIds[i]);
-    double term = pow(cashFlows[i], power) * pow(discountFactor, power) * probabilities[i];
+  double total = 0.0;
+  R_xlen_t n = cashFlows.size();
+
+  for (R_xlen_t i = 0; i < n; ++i) {
+    double discountFactor = std::pow(1.0 + interestRates[i], -timeIds[i]);
+    double term = std::pow(cashFlows[i], power) *
+      std::pow(discountFactor, power) * probabilities[i];
     total += term;
   }
 
   return total;
 }
 
-
 // [[Rcpp::export(name=".fExnCpp")]]
 double fExnCpp(double T, double y, double n, double i)
 {
   double out;
-  if(T<y+n)
-    out=0;
+  if(T < y + n)
+    out = 0;
   else
-    out=pow(1+i,-n);
+    out = std::pow(1 + i, -n);
   return out;
 }
-
-
 
 // [[Rcpp::export(name=".fAxnCpp")]]
 double fAxnCpp(double T, double y, double n, double i, double m, double k=1)
 {
-  double out=0;
-  if ((T>=y+m) && (T<=y+m+n-1/k))
-    out=pow(1+i,-(T-y+1/k));
+  check_positive_frequency(k);
+
+  double out = 0;
+  if ((T >= y + m) && (T <= y + m + n - 1 / k))
+    out = std::pow(1 + i, -(T - y + 1 / k));
   else
-    out=0;
+    out = 0;
   return out;
 }
-
-
 
 // [[Rcpp::export(name=".fIAxnCpp")]]
 double fIAxnCpp(double T, double y, double n, double i, double m, double k=1) {
+  check_positive_frequency(k);
+
   double out;
-  if ((T>=y+m) && (T<=y+m+n-1/k))
-    out=(T-(y+m)+1/k)*pow(1+i,-(T-y+1/k));
-  else out=0;
+  if ((T >= y + m) && (T <= y + m + n - 1 / k))
+    out = (T - (y + m) + 1 / k) *
+      std::pow(1 + i, -(T - y + 1 / k));
+  else
+    out = 0;
   return out;
 }
-
-
 
 // [[Rcpp::export(name=".fDAxnCpp")]]
 double fDAxnCpp(double T, double y, double n, double i, double m, double k=1) {
+  check_positive_frequency(k);
+
   double out;
-  if ((T>=y+m) && (T<=y+m+n-1/k))
-    out=(n-(T-(y+m)+1/k))*pow(1+i,-(T-y+1/k));
+  if ((T >= y + m) && (T <= y + m + n - 1 / k))
+    out = (n - (T - (y + m) + 1 / k)) *
+      std::pow(1 + i, -(T - y + 1 / k));
   else
-    out=0;
+    out = 0;
   return out;
 }
-
-
-
-// TODO: move faxn
 
 // [[Rcpp::export(name=".fAExnCpp")]]
 double fAExnCpp(double T, double y, double n, double i, double k=1)
 {
+  check_positive_frequency(k);
+
   double out;
-  if ((T>=y) && (T<=y+n-1/k))
-    out=pow(1+i,-(T-y+1/k));
+  if ((T >= y) && (T <= y + n - 1 / k))
+    out = std::pow(1 + i, -(T - y + 1 / k));
   else
-    out=pow(1+i,-n);
+    out = std::pow(1 + i, -n);
   return out;
 }

--- a/src/lifecontingenciesRcpp.cpp
+++ b/src/lifecontingenciesRcpp.cpp
@@ -75,9 +75,17 @@ double presentValueC(NumericVector cashFlows,
 
   for (R_xlen_t i = 0; i < n; ++i) {
     double discountFactor = std::pow(1.0 + interestRates[i], -timeIds[i]);
-    double term = std::pow(cashFlows[i], power) *
-      std::pow(discountFactor, power) * probabilities[i];
-    total += term;
+
+    // power = 1 is by far the common case for present values.  Avoid the
+    // second pow() call while preserving the original R calculation exactly
+    // at the level of its mathematical operations.
+    if (power == 1.0) {
+      total += cashFlows[i] * discountFactor * probabilities[i];
+    } else {
+      double term = std::pow(cashFlows[i], power) *
+        std::pow(discountFactor, power) * probabilities[i];
+      total += term;
+    }
   }
 
   return total;

--- a/tests/test-rcpp-backend.R
+++ b/tests/test-rcpp-backend.R
@@ -1,0 +1,124 @@
+require(lifecontingencies)
+
+# Regression tests for the native Rcpp kernels.
+# These tests intentionally exercise valid inputs only so that the numerical
+# behaviour can be compared before and after the hardening changes.
+
+# -----------------------------------------------------------------------------
+# Vector kernels
+# -----------------------------------------------------------------------------
+x <- c(1, 2, 3)
+y <- c(4, 0.5, -1)
+z <- c(0.5, 2, 3)
+
+stopifnot(all.equal(lifecontingencies:::.mult2sum(x, y), sum(x * y)))
+stopifnot(all.equal(lifecontingencies:::.mult3sum(x, y, z), sum(x * y * z)))
+
+# -----------------------------------------------------------------------------
+# Present value kernel
+# -----------------------------------------------------------------------------
+cf <- c(100, 50, 25)
+times <- c(1, 2, 4)
+rates <- c(0.03, 0.03, 0.05)
+probs <- c(0.9, 0.8, 0.7)
+
+pv_expected <- sum(cf * (1 + rates)^(-times) * probs)
+pv_actual <- lifecontingencies:::.presentValueC(
+  cashFlows = cf,
+  timeIds = times,
+  interestRates = rates,
+  probabilities = probs,
+  power = 1
+)
+stopifnot(all.equal(pv_actual, pv_expected, tolerance = 1e-12))
+
+pv2_expected <- sum(cf^2 * (1 + rates)^(-2 * times) * probs)
+pv2_actual <- lifecontingencies:::.presentValueC(
+  cashFlows = cf,
+  timeIds = times,
+  interestRates = rates,
+  probabilities = probs,
+  power = 2
+)
+stopifnot(all.equal(pv2_actual, pv2_expected, tolerance = 1e-12))
+
+# Public R wrapper must continue to agree with the native kernel.
+stopifnot(all.equal(
+  presentValue(cf, times, rates, probs),
+  pv_actual,
+  tolerance = 1e-12
+))
+
+# -----------------------------------------------------------------------------
+# Actuarial kernels
+# -----------------------------------------------------------------------------
+T <- 40
+age <- 30
+years <- 10
+i <- 0.04
+m <- 2
+k <- 2
+
+expected_exn <- if (T < age + years) 0 else (1 + i)^(-years)
+stopifnot(all.equal(
+  lifecontingencies:::.fExnCpp(T, age, years, i),
+  expected_exn,
+  tolerance = 1e-12
+))
+
+expected_axn <- if ((T >= age + m) && (T <= age + m + years - 1 / k)) {
+  (1 + i)^(-(T - age + 1 / k))
+} else 0
+stopifnot(all.equal(
+  lifecontingencies:::.fAxnCpp(T, age, years, i, m, k),
+  expected_axn,
+  tolerance = 1e-12
+))
+
+expected_iaxn <- if ((T >= age + m) && (T <= age + m + years - 1 / k)) {
+  (T - (age + m) + 1 / k) * (1 + i)^(-(T - age + 1 / k))
+} else 0
+stopifnot(all.equal(
+  lifecontingencies:::.fIAxnCpp(T, age, years, i, m, k),
+  expected_iaxn,
+  tolerance = 1e-12
+))
+
+expected_daxn <- if ((T >= age + m) && (T <= age + m + years - 1 / k)) {
+  (years - (T - (age + m) + 1 / k)) * (1 + i)^(-(T - age + 1 / k))
+} else 0
+stopifnot(all.equal(
+  lifecontingencies:::.fDAxnCpp(T, age, years, i, m, k),
+  expected_daxn,
+  tolerance = 1e-12
+))
+
+expected_aexn <- if ((T >= age) && (T <= age + years - 1 / k)) {
+  (1 + i)^(-(T - age + 1 / k))
+} else {
+  (1 + i)^(-years)
+}
+stopifnot(all.equal(
+  lifecontingencies:::.fAExnCpp(T, age, years, i, k),
+  expected_aexn,
+  tolerance = 1e-12
+))
+
+# Boundary checks for the piecewise actuarial kernels.
+T_in <- age + m
+T_out <- age + m + years
+stopifnot(lifecontingencies:::.fAxnCpp(T_in, age, years, i, m, k) != 0)
+stopifnot(lifecontingencies:::.fAxnCpp(T_out, age, years, i, m, k) == 0)
+
+# -----------------------------------------------------------------------------
+# Public presentValue input checks already implemented in R.
+# Keep these as regression tests while the native backend is hardened.
+# -----------------------------------------------------------------------------
+stopifnot(inherits(
+  try(presentValue(c(1, 2), c(1), 0.03, c(1, 1)), silent = TRUE),
+  "try-error"
+))
+stopifnot(inherits(
+  try(presentValue(c(1, 2), c(1, 2), 0.03, c(1)), silent = TRUE),
+  "try-error"
+))

--- a/tests/test-rcpp-backend.R
+++ b/tests/test-rcpp-backend.R
@@ -122,3 +122,28 @@ stopifnot(inherits(
   try(presentValue(c(1, 2), c(1, 2), 0.03, c(1)), silent = TRUE),
   "try-error"
 ))
+
+# Native backend rejects malformed vector inputs instead of relying on
+# unchecked indexing.
+stopifnot(inherits(
+  try(lifecontingencies:::.mult2sum(c(1, 2), c(1)), silent = TRUE),
+  "try-error"
+))
+stopifnot(inherits(
+  try(lifecontingencies:::.mult3sum(c(1, 2), c(1), c(1, 2)), silent = TRUE),
+  "try-error"
+))
+stopifnot(inherits(
+  try(lifecontingencies:::.presentValueC(
+    c(1, 2), c(1, 2), c(0.03), c(1, 1), 1
+  ), silent = TRUE),
+  "try-error"
+))
+
+# Invalid payment frequencies are rejected by the native actuarial kernels.
+for (bad_k in c(0, -1, NA_real_, NaN, Inf)) {
+  stopifnot(inherits(
+    try(lifecontingencies:::.fAxnCpp(40, 30, 10, 0.04, 2, bad_k), silent = TRUE),
+    "try-error"
+  ))
+}

--- a/tests/test-rcpp-backend.R
+++ b/tests/test-rcpp-backend.R
@@ -3,108 +3,164 @@ require(lifecontingencies)
 data("soa08Act")
 
 # -----------------------------------------------------------------------------
-# The C++ kernels are implementation details of the classical actuarial
-# functions.  The most important regression criterion is therefore numerical
-# agreement with the corresponding R implementation, not just agreement with
-# the same formula reproduced in C++.
+# Regression tests for the Rcpp backend.
+#
+# The primary criterion is numerical agreement with the corresponding
+# historical R implementation, where that implementation exists.
 # -----------------------------------------------------------------------------
 
-# Pure endowment: C++ kernel vs the classical Exn calculation.
-exn_cases <- expand.grid(
-  x = c(30, 60, 85),
-  n = c(5, 10, 20),
-  i = c(0.03, 0.06)
-)
-for (j in seq_len(nrow(exn_cases))) {
-  z <- exn_cases[j, ]
-  T <- z$x + z$n
-  cpp <- lifecontingencies:::.fExnCpp(T, z$x, z$n, z$i)
-  r <- Exn(soa08Act, x = z$x, n = z$n, i = z$i)
-  # The C++ kernel is a one-state survival kernel; for an arbitrary life table
-  # its direct value is used below only for the deterministic zero/discount
-  # cases. The public-function comparison is done for the native actuarial
-  # kernels whose corresponding legacy R implementations are available.
-  stopifnot(is.finite(cpp), is.finite(r))
+# -----------------------------------------------------------------------------
+# presentValue / presentValueC
+#
+# This is the R implementation that presentValueC() replaced in PR #39:
+#   v <- (1 + interestRates)^(-timeIds)
+#   sum(((cashFlows^power) * (v^power)) * probabilities)
+#
+# Keep this reference independent from the C++ implementation.
+# -----------------------------------------------------------------------------
+reference_present_value <- function(cashFlows, timeIds, interestRates,
+                                    probabilities, power = 1) {
+  v <- (1 + interestRates)^(-timeIds)
+  sum(((cashFlows^power) * (v^power)) * probabilities)
 }
 
-# -----------------------------------------------------------------------------
-# Axn: compare the current native implementation with the classical R
-# implementation used by the package's historical tests.
-# This follows tests/test-computation-time-act-capital.R, which compares
-# Axnvect with Axnold over age, term, deferment and payment frequency.
-# -----------------------------------------------------------------------------
-AXn <- Vectorize(lifecontingencies:::Axnold, "x")
-AxN <- Vectorize(lifecontingencies:::Axnold, "n")
-AxnM <- Vectorize(lifecontingencies:::Axnold, "m")
+test_cases <- list(
+  list(
+    cashFlows = c(100, -30, 50, 70),
+    timeIds = c(0, 0.5, 3, 6.25),
+    interestRates = 0.035,
+    probabilities = c(1, 0.9, 0.8, 0.65),
+    power = 1
+  ),
+  list(
+    cashFlows = c(10, 10, 10, 10, 10, 10, 110),
+    timeIds = 1:7,
+    interestRates = c(0.02, 0.021, 0.0225, 0.024, 0.0255, 0.027, 0.028),
+    probabilities = rep(0.995, 7),
+    power = 1
+  ),
+  list(
+    cashFlows = c(3, 5, 7),
+    timeIds = c(1, 2, 3),
+    interestRates = c(0.01, 0.015, 0.02),
+    probabilities = c(0.9, 0.8, 0.7),
+    power = 2
+  )
+)
 
-# Public/native implementation vs legacy/classical R implementation.
+for (case in test_cases) {
+  expected <- do.call(reference_present_value, case)
+  actual_public <- do.call(presentValue, case)
+  actual_cpp <- do.call(lifecontingencies:::.presentValueC, case)
+
+  stopifnot(all.equal(actual_public, expected, tolerance = 1e-12))
+  stopifnot(all.equal(actual_cpp, expected, tolerance = 1e-12))
+}
+
+# Scalar interest rate recycling, as performed by the public R wrapper.
+set.seed(123)
+cf <- rnorm(50, mean = 5, sd = 20)
+times <- seq(0.25, by = 0.25, length.out = length(cf))
+probs <- runif(length(cf), min = 0.2, max = 1)
+expected <- reference_present_value(cf, times, 0.018, probs)
+stopifnot(all.equal(
+  presentValue(cf, times, 0.018, probs),
+  expected,
+  tolerance = 1e-10
+))
+
+# -----------------------------------------------------------------------------
+# Axn: current implementation vs the historical Axnold implementation.
+#
+# This follows tests/test-computation-time-act-capital.R.
+# -----------------------------------------------------------------------------
+Axn_old_x <- Vectorize(lifecontingencies:::Axnold, "x")
+Axn_old_n <- Vectorize(lifecontingencies:::Axnold, "n")
+Axn_old_m <- Vectorize(lifecontingencies:::Axnold, "m")
+
 x_cases <- c(30:35 + 0.5, 60, 65, 80, 85)
+
 for (k in c(1, 2, 4)) {
   new <- Axn(soa08Act, x = x_cases, n = 10, i = 0.06, k = k)
-  old <- AXn(soa08Act, x = x_cases, n = 10, i = 0.06, k = k)
+  old <- Axn_old_x(soa08Act, x = x_cases, n = 10, i = 0.06, k = k)
   stopifnot(all.equal(new, old, tolerance = 1e-10))
 }
 
-# Variation over term and deferment, mirroring the historical tests.
 for (k in c(1, 2, 4)) {
   new_n <- Axn(soa08Act, x = 33, n = 1:20, i = 0.06, k = k)
-  old_n <- AxN(soa08Act, x = 33, n = 1:20, i = 0.06, k = k)
+  old_n <- Axn_old_n(soa08Act, x = 33, n = 1:20, i = 0.06, k = k)
   stopifnot(all.equal(new_n, old_n, tolerance = 1e-10))
 
   new_m <- Axn(soa08Act, x = 33, n = 20, m = 0:10, i = 0.06, k = k)
-  old_m <- AxnM(soa08Act, x = 33, n = 20, m = 0:10, i = 0.06, k = k)
+  old_m <- Axn_old_m(soa08Act, x = 33, n = 20, m = 0:10, i = 0.06, k = k)
   stopifnot(all.equal(new_m, old_m, tolerance = 1e-10))
 }
 
-# A direct classical actuarial benchmark from the existing test suite.
-# The package historically checks the value against Bowers (p. 339).
+# Historical actuarial benchmark from the existing test suite (Bowers p. 339).
 stopifnot(
   abs(Axn(soa08Act, x = 30, i = 0.06, k = 4) - 0.1048) < 5e-4
 )
 
+# Explicit cases from the historical test:
+# basic deferred insurance, non-integer ages and k > 1.
+AxncheckR <- function(object, x, m, n) {
+  i <- object@interest
+  f <- function(t)
+    pxt(object, x = x, t = t) * qxt(object, x = x + t, t = 1)
+  prob <- sapply(m:(m + n - 1), f)
+  rowSums(prob / ((1 + i)^(m + 1):(m + n)))
+}
+
+stopifnot(all.equal(
+  Axn(soa08Act, x = 65:66, n = 1, m = 1),
+  AxncheckR(soa08Act, x = 65:66, m = 1, n = 1),
+  tolerance = 1e-10
+))
+
+x <- 30:35 + 1 / 2
+stopifnot(all.equal(
+  Axn(soa08Act, x = x),
+  Axn_old_x(soa08Act, x = x),
+  tolerance = 1e-10
+))
+
 # -----------------------------------------------------------------------------
-# axn: compare the current implementation with the classical R axnold
-# implementation for due and immediate payments, including the vectorized
-# age/term/deferment checks used by the package's existing tests.
+# axn: current implementation vs the historical axnold implementation.
 # -----------------------------------------------------------------------------
-aXn <- Vectorize(lifecontingencies:::axnold, "x")
-axN <- Vectorize(lifecontingencies:::axnold, "n")
-axnM <- Vectorize(lifecontingencies:::axnold, "m")
+axn_old_x <- Vectorize(lifecontingencies:::axnold, "x")
+axn_old_n <- Vectorize(lifecontingencies:::axnold, "n")
+axn_old_m <- Vectorize(lifecontingencies:::axnold, "m")
 
 for (payment in c("due", "arrears", "immediate", "advance")) {
   new_x <- axn(soa08Act, x = 1:100, payment = payment)
-  old_x <- aXn(soa08Act, x = 1:100, payment = payment)
+  old_x <- axn_old_x(soa08Act, x = 1:100, payment = payment)
   stopifnot(all.equal(new_x, old_x, tolerance = 1e-10))
 
   new_n <- axn(soa08Act, x = 33, n = 10:30, payment = payment)
-  old_n <- axN(soa08Act, x = 33, n = 10:30, payment = payment)
+  old_n <- axn_old_n(soa08Act, x = 33, n = 10:30, payment = payment)
   stopifnot(all.equal(new_n, old_n, tolerance = 1e-10))
 
   new_m <- axn(soa08Act, x = 33, n = 30, m = 0:10, payment = payment)
-  old_m <- axnM(soa08Act, x = 33, n = 30, m = 0:10, payment = payment)
+  old_m <- axn_old_m(soa08Act, x = 33, n = 30, m = 0:10, payment = payment)
   stopifnot(all.equal(new_m, old_m, tolerance = 1e-10))
 }
 
-# High-age and non-integer-age cases, explicitly retained from the historical
-# actuarial-function tests.
 x <- 85:90
 stopifnot(all.equal(
   axn(soa08Act, x = x, payment = "advance"),
-  aXn(soa08Act, x = x, payment = "advance"),
+  axn_old_x(soa08Act, x = x, payment = "advance"),
   tolerance = 1e-10
 ))
 
 x <- 30:35 + 1 / 2
 stopifnot(all.equal(
   axn(soa08Act, x = x, payment = "advance"),
-  aXn(soa08Act, x = x, payment = "advance"),
+  axn_old_x(soa08Act, x = x, payment = "advance"),
   tolerance = 1e-10
 ))
 
 # -----------------------------------------------------------------------------
-# Native helper kernels: verify their numerical values on deterministic cases
-# against the corresponding actuarial identities. These are secondary checks;
-# the public-function comparisons above are the primary regression criterion.
+# Native helper kernels: deterministic checks of their numerical identities.
 # -----------------------------------------------------------------------------
 T <- 40
 age <- 30
@@ -140,26 +196,44 @@ stopifnot(all.equal(
   tolerance = 1e-12
 ))
 
+stopifnot(all.equal(
+  lifecontingencies:::.fAExnCpp(T, age, years, i, k),
+  if ((T >= age) && (T <= age + years - 1 / k))
+    (1 + i)^(-(T - age + 1 / k))
+  else
+    (1 + i)^(-years),
+  tolerance = 1e-12
+))
+
 # -----------------------------------------------------------------------------
-# Rcpp input validation: native entry points must reject malformed vectors
-# rather than relying on unchecked indexing.
+# Native input validation.
 # -----------------------------------------------------------------------------
 stopifnot(inherits(
   try(lifecontingencies:::.mult2sum(c(1, 2), c(1)), silent = TRUE),
   "try-error"
 ))
+
 stopifnot(inherits(
   try(lifecontingencies:::.mult3sum(c(1, 2), c(1), c(1, 2)), silent = TRUE),
   "try-error"
 ))
+
 stopifnot(inherits(
-  try(lifecontingencies:::.presentValueC(c(1, 2), c(1, 2), c(0.03), c(1, 1), 1), silent = TRUE),
+  try(
+    lifecontingencies:::.presentValueC(
+      c(1, 2), c(1, 2), c(0.03), c(1, 1), 1
+    ),
+    silent = TRUE
+  ),
   "try-error"
 ))
 
 for (bad_k in c(0, -1, NA_real_, NaN, Inf)) {
   stopifnot(inherits(
-    try(lifecontingencies:::.fAxnCpp(40, 30, 10, 0.04, 2, bad_k), silent = TRUE),
+    try(
+      lifecontingencies:::.fAxnCpp(40, 30, 10, 0.04, 2, bad_k),
+      silent = TRUE
+    ),
     "try-error"
   ))
 }

--- a/tests/test-rcpp-backend.R
+++ b/tests/test-rcpp-backend.R
@@ -51,14 +51,37 @@ test_cases <- list(
 for (case in test_cases) {
   expected <- do.call(reference_present_value, case)
   actual_public <- do.call(presentValue, case)
-  actual_cpp <- do.call(lifecontingencies:::.presentValueC, case)
+
+  # The public R wrapper recycles interestRates before calling the native
+  # kernel. Reproduce that historical behaviour before testing .presentValueC.
+  case_cpp <- case
+  case_cpp$interestRates <- rep(
+    case$interestRates,
+    length.out = length(case$timeIds)
+  )
+  actual_cpp <- do.call(lifecontingencies:::.presentValueC, case_cpp)
 
   stopifnot(all.equal(actual_public, expected, tolerance = 1e-12))
   stopifnot(all.equal(actual_cpp, expected, tolerance = 1e-12))
 }
 
-# Scalar interest rate recycling, as performed by the public R wrapper.
+# Randomized regression test against the historical R implementation.
 set.seed(123)
+for (power in c(1, 2, 3)) {
+  cf <- rnorm(50, mean = 5, sd = 20)
+  times <- seq(0.25, by = 0.25, length.out = length(cf))
+  rates <- runif(length(cf), min = 0.005, max = 0.06)
+  probs <- runif(length(cf), min = 0.2, max = 1)
+
+  expected <- reference_present_value(cf, times, rates, probs, power)
+  actual_cpp <- lifecontingencies:::.presentValueC(
+    cf, times, rates, probs, power
+  )
+
+  stopifnot(all.equal(actual_cpp, expected, tolerance = 1e-10))
+}
+
+# Scalar interest rate recycling, as performed by the public R wrapper.
 cf <- rnorm(50, mean = 5, sd = 20)
 times <- seq(0.25, by = 0.25, length.out = length(cf))
 probs <- runif(length(cf), min = 0.2, max = 1)
@@ -141,7 +164,7 @@ for (payment in c("due", "arrears", "immediate", "advance")) {
   stopifnot(all.equal(new_n, old_n, tolerance = 1e-10))
 
   new_m <- axn(soa08Act, x = 33, n = 30, m = 0:10, payment = payment)
-  old_m <- axn_old_m(soa08Act, x = 33, n = 30, m = 0:10, payment = payment)
+  old_m <- axn_old_m(soa08Act, x = 33, m = 0:10, n = 30, payment = payment)
   stopifnot(all.equal(new_m, old_m, tolerance = 1e-10))
 }
 

--- a/tests/test-rcpp-backend.R
+++ b/tests/test-rcpp-backend.R
@@ -1,56 +1,110 @@
 require(lifecontingencies)
 
-# Regression tests for the native Rcpp kernels.
-# These tests intentionally exercise valid inputs only so that the numerical
-# behaviour can be compared before and after the hardening changes.
+data("soa08Act")
 
 # -----------------------------------------------------------------------------
-# Vector kernels
+# The C++ kernels are implementation details of the classical actuarial
+# functions.  The most important regression criterion is therefore numerical
+# agreement with the corresponding R implementation, not just agreement with
+# the same formula reproduced in C++.
 # -----------------------------------------------------------------------------
-x <- c(1, 2, 3)
-y <- c(4, 0.5, -1)
-z <- c(0.5, 2, 3)
 
-stopifnot(all.equal(lifecontingencies:::.mult2sum(x, y), sum(x * y)))
-stopifnot(all.equal(lifecontingencies:::.mult3sum(x, y, z), sum(x * y * z)))
-
-# -----------------------------------------------------------------------------
-# Present value kernel
-# -----------------------------------------------------------------------------
-cf <- c(100, 50, 25)
-times <- c(1, 2, 4)
-rates <- c(0.03, 0.03, 0.05)
-probs <- c(0.9, 0.8, 0.7)
-
-pv_expected <- sum(cf * (1 + rates)^(-times) * probs)
-pv_actual <- lifecontingencies:::.presentValueC(
-  cashFlows = cf,
-  timeIds = times,
-  interestRates = rates,
-  probabilities = probs,
-  power = 1
+# Pure endowment: C++ kernel vs the classical Exn calculation.
+exn_cases <- expand.grid(
+  x = c(30, 60, 85),
+  n = c(5, 10, 20),
+  i = c(0.03, 0.06)
 )
-stopifnot(all.equal(pv_actual, pv_expected, tolerance = 1e-12))
+for (j in seq_len(nrow(exn_cases))) {
+  z <- exn_cases[j, ]
+  T <- z$x + z$n
+  cpp <- lifecontingencies:::.fExnCpp(T, z$x, z$n, z$i)
+  r <- Exn(soa08Act, x = z$x, n = z$n, i = z$i)
+  # The C++ kernel is a one-state survival kernel; for an arbitrary life table
+  # its direct value is used below only for the deterministic zero/discount
+  # cases. The public-function comparison is done for the native actuarial
+  # kernels whose corresponding legacy R implementations are available.
+  stopifnot(is.finite(cpp), is.finite(r))
+}
 
-pv2_expected <- sum(cf^2 * (1 + rates)^(-2 * times) * probs)
-pv2_actual <- lifecontingencies:::.presentValueC(
-  cashFlows = cf,
-  timeIds = times,
-  interestRates = rates,
-  probabilities = probs,
-  power = 2
+# -----------------------------------------------------------------------------
+# Axn: compare the current native implementation with the classical R
+# implementation used by the package's historical tests.
+# This follows tests/test-computation-time-act-capital.R, which compares
+# Axnvect with Axnold over age, term, deferment and payment frequency.
+# -----------------------------------------------------------------------------
+AXn <- Vectorize(lifecontingencies:::Axnold, "x")
+AxN <- Vectorize(lifecontingencies:::Axnold, "n")
+AxnM <- Vectorize(lifecontingencies:::Axnold, "m")
+
+# Public/native implementation vs legacy/classical R implementation.
+x_cases <- c(30:35 + 0.5, 60, 65, 80, 85)
+for (k in c(1, 2, 4)) {
+  new <- Axn(soa08Act, x = x_cases, n = 10, i = 0.06, k = k)
+  old <- AXn(soa08Act, x = x_cases, n = 10, i = 0.06, k = k)
+  stopifnot(all.equal(new, old, tolerance = 1e-10))
+}
+
+# Variation over term and deferment, mirroring the historical tests.
+for (k in c(1, 2, 4)) {
+  new_n <- Axn(soa08Act, x = 33, n = 1:20, i = 0.06, k = k)
+  old_n <- AxN(soa08Act, x = 33, n = 1:20, i = 0.06, k = k)
+  stopifnot(all.equal(new_n, old_n, tolerance = 1e-10))
+
+  new_m <- Axn(soa08Act, x = 33, n = 20, m = 0:10, i = 0.06, k = k)
+  old_m <- AxnM(soa08Act, x = 33, n = 20, m = 0:10, i = 0.06, k = k)
+  stopifnot(all.equal(new_m, old_m, tolerance = 1e-10))
+}
+
+# A direct classical actuarial benchmark from the existing test suite.
+# The package historically checks the value against Bowers (p. 339).
+stopifnot(
+  abs(Axn(soa08Act, x = 30, i = 0.06, k = 4) - 0.1048) < 5e-4
 )
-stopifnot(all.equal(pv2_actual, pv2_expected, tolerance = 1e-12))
 
-# Public R wrapper must continue to agree with the native kernel.
+# -----------------------------------------------------------------------------
+# axn: compare the current implementation with the classical R axnold
+# implementation for due and immediate payments, including the vectorized
+# age/term/deferment checks used by the package's existing tests.
+# -----------------------------------------------------------------------------
+aXn <- Vectorize(lifecontingencies:::axnold, "x")
+axN <- Vectorize(lifecontingencies:::axnold, "n")
+axnM <- Vectorize(lifecontingencies:::axnold, "m")
+
+for (payment in c("due", "arrears", "immediate", "advance")) {
+  new_x <- axn(soa08Act, x = 1:100, payment = payment)
+  old_x <- aXn(soa08Act, x = 1:100, payment = payment)
+  stopifnot(all.equal(new_x, old_x, tolerance = 1e-10))
+
+  new_n <- axn(soa08Act, x = 33, n = 10:30, payment = payment)
+  old_n <- axN(soa08Act, x = 33, n = 10:30, payment = payment)
+  stopifnot(all.equal(new_n, old_n, tolerance = 1e-10))
+
+  new_m <- axn(soa08Act, x = 33, n = 30, m = 0:10, payment = payment)
+  old_m <- axnM(soa08Act, x = 33, n = 30, m = 0:10, payment = payment)
+  stopifnot(all.equal(new_m, old_m, tolerance = 1e-10))
+}
+
+# High-age and non-integer-age cases, explicitly retained from the historical
+# actuarial-function tests.
+x <- 85:90
 stopifnot(all.equal(
-  presentValue(cf, times, rates, probs),
-  pv_actual,
-  tolerance = 1e-12
+  axn(soa08Act, x = x, payment = "advance"),
+  aXn(soa08Act, x = x, payment = "advance"),
+  tolerance = 1e-10
+))
+
+x <- 30:35 + 1 / 2
+stopifnot(all.equal(
+  axn(soa08Act, x = x, payment = "advance"),
+  aXn(soa08Act, x = x, payment = "advance"),
+  tolerance = 1e-10
 ))
 
 # -----------------------------------------------------------------------------
-# Actuarial kernels
+# Native helper kernels: verify their numerical values on deterministic cases
+# against the corresponding actuarial identities. These are secondary checks;
+# the public-function comparisons above are the primary regression criterion.
 # -----------------------------------------------------------------------------
 T <- 40
 age <- 30
@@ -59,72 +113,37 @@ i <- 0.04
 m <- 2
 k <- 2
 
-expected_exn <- if (T < age + years) 0 else (1 + i)^(-years)
 stopifnot(all.equal(
   lifecontingencies:::.fExnCpp(T, age, years, i),
-  expected_exn,
+  if (T < age + years) 0 else (1 + i)^(-years),
   tolerance = 1e-12
 ))
 
-expected_axn <- if ((T >= age + m) && (T <= age + m + years - 1 / k)) {
-  (1 + i)^(-(T - age + 1 / k))
-} else 0
 stopifnot(all.equal(
   lifecontingencies:::.fAxnCpp(T, age, years, i, m, k),
-  expected_axn,
+  if ((T >= age + m) && (T <= age + m + years - 1 / k))
+    (1 + i)^(-(T - age + 1 / k)) else 0,
   tolerance = 1e-12
 ))
 
-expected_iaxn <- if ((T >= age + m) && (T <= age + m + years - 1 / k)) {
-  (T - (age + m) + 1 / k) * (1 + i)^(-(T - age + 1 / k))
-} else 0
 stopifnot(all.equal(
   lifecontingencies:::.fIAxnCpp(T, age, years, i, m, k),
-  expected_iaxn,
+  if ((T >= age + m) && (T <= age + m + years - 1 / k))
+    (T - (age + m) + 1 / k) * (1 + i)^(-(T - age + 1 / k)) else 0,
   tolerance = 1e-12
 ))
 
-expected_daxn <- if ((T >= age + m) && (T <= age + m + years - 1 / k)) {
-  (years - (T - (age + m) + 1 / k)) * (1 + i)^(-(T - age + 1 / k))
-} else 0
 stopifnot(all.equal(
   lifecontingencies:::.fDAxnCpp(T, age, years, i, m, k),
-  expected_daxn,
+  if ((T >= age + m) && (T <= age + m + years - 1 / k))
+    (years - (T - (age + m) + 1 / k)) * (1 + i)^(-(T - age + 1 / k)) else 0,
   tolerance = 1e-12
 ))
 
-expected_aexn <- if ((T >= age) && (T <= age + years - 1 / k)) {
-  (1 + i)^(-(T - age + 1 / k))
-} else {
-  (1 + i)^(-years)
-}
-stopifnot(all.equal(
-  lifecontingencies:::.fAExnCpp(T, age, years, i, k),
-  expected_aexn,
-  tolerance = 1e-12
-))
-
-# Boundary checks for the piecewise actuarial kernels.
-T_in <- age + m
-T_out <- age + m + years
-stopifnot(lifecontingencies:::.fAxnCpp(T_in, age, years, i, m, k) != 0)
-stopifnot(lifecontingencies:::.fAxnCpp(T_out, age, years, i, m, k) == 0)
-
 # -----------------------------------------------------------------------------
-# Public presentValue input checks already implemented in R.
-# Keep these as regression tests while the native backend is hardened.
+# Rcpp input validation: native entry points must reject malformed vectors
+# rather than relying on unchecked indexing.
 # -----------------------------------------------------------------------------
-stopifnot(inherits(
-  try(presentValue(c(1, 2), c(1), 0.03, c(1, 1)), silent = TRUE),
-  "try-error"
-))
-stopifnot(inherits(
-  try(presentValue(c(1, 2), c(1, 2), 0.03, c(1)), silent = TRUE),
-  "try-error"
-))
-
-# Native backend rejects malformed vector inputs instead of relying on
-# unchecked indexing.
 stopifnot(inherits(
   try(lifecontingencies:::.mult2sum(c(1, 2), c(1)), silent = TRUE),
   "try-error"
@@ -134,13 +153,10 @@ stopifnot(inherits(
   "try-error"
 ))
 stopifnot(inherits(
-  try(lifecontingencies:::.presentValueC(
-    c(1, 2), c(1, 2), c(0.03), c(1, 1), 1
-  ), silent = TRUE),
+  try(lifecontingencies:::.presentValueC(c(1, 2), c(1, 2), c(0.03), c(1, 1), 1), silent = TRUE),
   "try-error"
 ))
 
-# Invalid payment frequencies are rejected by the native actuarial kernels.
 for (bad_k in c(0, -1, NA_real_, NaN, Inf)) {
   stopifnot(inherits(
     try(lifecontingencies:::.fAxnCpp(40, 30, 10, 0.04, 2, bad_k), silent = TRUE),

--- a/tests/testthat/testPresentValue.R
+++ b/tests/testthat/testPresentValue.R
@@ -2,7 +2,10 @@ library(lifecontingencies)
 
 context("Present value engine")
 
-reference_present_value <- function(cashFlows, timeIds, interestRates, probabilities, power = 1) {
+# This is intentionally the R implementation that predates .presentValueC.
+# It is kept here as an independent numerical reference for the native kernel.
+reference_present_value <- function(cashFlows, timeIds, interestRates,
+                                    probabilities, power = 1) {
   rates <- rep(interestRates, length.out = length(timeIds))
   discounts <- (1 + rates)^(-timeIds)
   sum((cashFlows^power) * (discounts^power) * probabilities)
@@ -75,4 +78,71 @@ test_that("presentValue defaults probabilities to one", {
                            timeIds = times,
                            interestRates = rate)
   expect_identical(implicit, explicit)
+})
+
+# Test the C++ kernel itself against the historical R implementation.  The
+# rates are recycled exactly as presentValue() does before calling the kernel.
+test_that("presentValueC agrees with the historical R implementation", {
+  cases <- list(
+    list(
+      cf = c(100, -30, 50, 70),
+      times = c(0, 0.5, 3, 6.25),
+      rates = 0.035,
+      probs = c(1, 0.9, 0.8, 0.65),
+      power = 1
+    ),
+    list(
+      cf = c(10, 20, 30, 110),
+      times = c(1, 2, 4, 7),
+      rates = c(0.02, 0.021, 0.024, 0.028),
+      probs = c(0.995, 0.99, 0.97, 0.95),
+      power = 1
+    ),
+    list(
+      cf = c(3, 5, 7),
+      times = c(1, 2, 3),
+      rates = c(0.01, 0.015, 0.02),
+      probs = c(0.9, 0.8, 0.7),
+      power = 2
+    )
+  )
+
+  for (case in cases) {
+    rates <- rep(case$rates, length.out = length(case$times))
+    expected <- reference_present_value(
+      case$cf, case$times, case$rates, case$probs, case$power
+    )
+    actual <- lifecontingencies:::.presentValueC(
+      cashFlows = case$cf,
+      timeIds = case$times,
+      interestRates = rates,
+      probabilities = case$probs,
+      power = case$power
+    )
+    expect_equal(actual, expected, tolerance = 1e-12)
+  }
+})
+
+test_that("presentValueC agrees with the R reference over randomized cases", {
+  set.seed(20260817)
+
+  for (rep in seq_len(100)) {
+    n <- sample(1:50, 1)
+    cf <- rnorm(n, mean = 10, sd = 25)
+    times <- sort(runif(n, min = 0, max = 30))
+    rates <- sample(c(0.01, 0.015, 0.02, 0.025), sample(1:3, 1), replace = TRUE)
+    probs <- runif(n, min = 0.1, max = 1)
+    power <- sample(c(0.5, 1, 2), 1)
+
+    expected <- reference_present_value(cf, times, rates, probs, power)
+    actual <- lifecontingencies:::.presentValueC(
+      cashFlows = cf,
+      timeIds = times,
+      interestRates = rep(rates, length.out = n),
+      probabilities = probs,
+      power = power
+    )
+
+    expect_equal(actual, expected, tolerance = 1e-12)
+  }
 })


### PR DESCRIPTION
## Summary
- add regression tests covering the Rcpp kernels and their historical R references
- compare `presentValueC()` directly with the pre-Rcpp implementation recovered from PR #39
- mirror the package's existing `Axn`/`Axnold` and `axn`/`axnold` numerical regression patterns
- reject mismatched vector lengths in native kernels before indexed access
- reject non-finite or non-positive payment frequencies (`k`) in actuarial kernels
- use `R_xlen_t` for R vector sizes and `<cmath>`/`std::pow`

## R-layer review
The public `presentValue()` wrapper already recycles `interestRates` and validates the key dimensions before calling `.presentValueC()`. The native checks are defense-in-depth for internal native entry points and do not replace the R-layer semantics.

The existing `interestRates` warning + recycling behaviour is intentionally unchanged.

## Validation
The numerical tests use the historical R implementation where it exists, rather than reproducing the C++ formula in the test. `presentValueC()` is compared directly with the R implementation that it replaced in PR #39. `Axn`/`axn` comparisons follow the package's existing historical tests.

No generated Rcpp wrapper files were modified because exported signatures are unchanged.