### PR TITLE
Automate GitHub releases from package version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Sync GitHub release with DESCRIPTION
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Read package version
+        id: version
+        shell: bash
+        run: |
+          VERSION=$(sed -n 's/^Version:[[:space:]]*//p' DESCRIPTION | head -n 1)
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid or missing package version: '$VERSION'"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether the release already exists
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        shell: bash
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "GitHub release $TAG already exists; nothing to do."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "GitHub release $TAG does not exist; it will be created."
+          fi
+
+      - name: Create GitHub release
+        if: steps.release.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          gh release create "$TAG" \
+            --target "${GITHUB_SHA}" \
+            --title "lifecontingencies $VERSION" \
+            --generate-notes


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow that reads the package version from `DESCRIPTION`
- create the corresponding `vX.Y.Z` GitHub Release automatically when it does not already exist
- keep GitHub's latest release synchronized with the package version without changing package functionality

## Why
The repository is currently at version 1.5.2, while GitHub still identifies v1.4.4 as the latest release. The new workflow makes the GitHub Release metadata follow the authoritative package version in `DESCRIPTION`.

The workflow is idempotent: if the release already exists, it does nothing.

## Validation
The workflow syntax and existing repository CI configuration were inspected. No R package source code or package functions are modified.