### PR TITLE
fix: use dynamic CRAN version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ devtools::install_github('spedygiorgio/lifecontingencies')
 
 ![alt tag](https://travis-ci.org/spedygiorgio/lifecontingencies.svg?branch=master)
 [![Downloads](http://cranlogs.r-pkg.org/badges/lifecontingencies)](https://cran.r-project.org/package=lifecontingencies)
-[![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/lifecontingencies)](https://cran.r-project.org/package=lifecontingencies)
+[![CRAN_Status_Badge](https://img.shields.io/cran/v/lifecontingencies?label=CRAN)](https://CRAN.R-project.org/package=lifecontingencies)
 [![Research software impact](http://depsy.org/api/package/cran/lifecontingencies/badge.svg)](http://depsy.org/package/r/lifecontingencies)
 [![R-CMD-check](https://github.com/spedygiorgio/lifecontingencies/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/spedygiorgio/lifecontingencies/actions/workflows/R-CMD-check.yaml)
 


### PR DESCRIPTION
## What changed
- Replace the legacy `r-pkg.org` CRAN version badge in `README.md` with a dynamic CRAN version badge served by Shields.
- Link the badge to the canonical CRAN package page.

## Why
The previous badge could display a stale CRAN version. The new badge retrieves the CRAN version dynamically, so the GitHub landing page does not require a repository change every time a new release is published to CRAN.

## Validation
- Confirmed the repository development version is `1.5.2` in `DESCRIPTION`.
- Compared the PR branch with `master`: one file changed (`README.md`), with only the CRAN badge URL changed.