### PR TITLE
Add manual Rcpp benchmark workflow

### DIFF
--- a/.github/workflows/benchmark-rcpp.yml
+++ b/.github/workflows/benchmark-rcpp.yml
@@ -1,0 +1,28 @@
+name: benchmark-rcpp
+
+on:
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'release'
+
+      - name: Set up R dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::bench
+          needs: check
+
+      - name: Install package
+        run: R CMD INSTALL .
+
+      - name: Run Rcpp benchmark
+        run: Rscript inst/benchmarks/benchmark-rcpp.R


### PR DESCRIPTION
The manual `workflow_dispatch` benchmark workflow currently exists only on PR #50's feature branch, so GitHub does not expose it in the Actions UI. GitHub requires a workflow_dispatch workflow file to be present on the default branch before it can be manually triggered; once merged, the Actions UI will allow selecting `agent/rcpp-optimization-round2` as the branch to benchmark. This PR adds only the workflow configuration and does not modify package code.