### PR TITLE
Fix CI vignette build order

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -250,6 +250,15 @@ jobs:
           cat("tlmgr: ", Sys.which("tlmgr"), "\n", sep = "")
           cat("TinyTeX root: ", tinytex::tinytex_root(), "\n", sep = "")
 
+      - name: Install package for vignette build
+        shell: Rscript {0}
+        run: |
+          os <- Sys.info()[["sysname"]]
+          rbin <- file.path(R.home("bin"), if (os == "Windows") "R.exe" else "R")
+          status <- system2(rbin, c("CMD", "INSTALL", "--no-multiarch", "--no-build-vignettes", "."))
+          if (!identical(status, 0L)) stop("R CMD INSTALL failed with status ", status)
+          cat("Installed lifecontingencies from source for vignette execution.\n")
+
       - name: Build vignettes
         shell: Rscript {0}
         run: |


### PR DESCRIPTION
## Problem
The full `R-CMD-check` job builds vignettes directly from the source tree before `lifecontingencies` is installed. Vignettes that call `library(lifecontingencies)` therefore fail with `there is no package called 'lifecontingencies'`.

## Fix
Install the package from the source tree with `--no-build-vignettes` immediately before the explicit vignette build. This makes the package available to vignette code without changing package functions or vignette content.

## Expected result
The full CI matrix can build the vignettes in the same environment in which they are subsequently checked.