### PR TITLE
Fix R-devel CI hang on Ubuntu mirror

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -39,6 +39,18 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Use stable Ubuntu mirror for R-devel
+        if: runner.os == 'Linux' && matrix.config.r == 'devel'
+        shell: bash
+        run: |
+          for file in /etc/apt/apt-mirrors.txt /etc/apt/sources.list /etc/apt/sources.list.d/*.sources; do
+            if [ -f "$file" ]; then
+              sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' "$file"
+            fi
+          done
+          echo "Ubuntu APT sources used for R-devel:"
+          grep -R "archive.ubuntu.com\|azure.archive.ubuntu.com" /etc/apt/apt-mirrors.txt /etc/apt/sources.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true
+
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:
@@ -127,8 +139,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: ubuntu-latest, r: 'release' }
-          - { os: ubuntu-latest, r: 'devel', http-user-agent: 'release' }
+          - { os: ubuntu-latest,  r: 'release' }
+          - { os: ubuntu-latest,  r: 'devel', http-user-agent: 'release' }
           - { os: windows-latest, r: 'release' }
           - { os: windows-latest, r: 'devel', http-user-agent: 'release' }
           - { os: macos-latest, r: 'release' }
@@ -142,6 +154,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+
+      - name: Use stable Ubuntu mirror for R-devel
+        if: runner.os == 'Linux' && matrix.config.r == 'devel'
+        shell: bash
+        run: |
+          for file in /etc/apt/apt-mirrors.txt /etc/apt/sources.list /etc/apt/sources.list.d/*.sources; do
+            if [ -f "$file" ]; then
+              sudo sed -i 's|azure.archive.ubuntu.com|archive.ubuntu.com|g' "$file"
+            fi
+          done
+          echo "Ubuntu APT sources used for R-devel:"
+          grep -R "archive.ubuntu.com\|azure.archive.ubuntu.com" /etc/apt/apt-mirrors.txt /etc/apt/sources.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v2


### PR DESCRIPTION
## Problem
The Ubuntu R-devel job can hang for hours in `r-lib/actions/setup-r@v2` while `apt-get update` retries the GitHub runner's `azure.archive.ubuntu.com` mirror. The cancelled run on August 18, 2026 spent about 2 hours in `Setup R` and never reached package checks.

## Fix
For Linux R-devel jobs only, replace the runner-provided Azure Ubuntu mirror with the standard `archive.ubuntu.com` mirror before `setup-r@v2` runs. The R-devel matrix entry is retained unchanged, so CRAN-facing compatibility testing continues on every CI verification.

The same guard is applied to both the pull-request matrix and the full matrix.

## Scope
This changes only CI infrastructure; no package code, tests, or R versions are changed.