### PR TITLE
Fix annuity-immediate and annuity-due terminology

### DIFF
--- a/man/accumulatedValue.Rd
+++ b/man/accumulatedValue.Rd
@@ -1,74 +1,29 @@
 \name{accumulatedValue}
 \alias{accumulatedValue}
 
-\title{
-	Function to evaluate the accumulated value.
-}
-\description{
-	This functions returns the value at time n of a series of equally spaced payments of 1.
-}
-\usage{
-	accumulatedValue(i, n,m=0, k,type = "immediate")
-}
-
+\title{Function to evaluate the accumulated value.}
+\description{This functions returns the value at time n of a series of equally spaced payments of 1.}
+\usage{accumulatedValue(i, n,m=0, k,type = "immediate")}
 \arguments{
-\item{i}{
-	Effective interest rate expressed in decimal form. E.g. 0.03 means 3\%.
+\item{i}{Effective interest rate expressed in decimal form. E.g. 0.03 means 3\%.}
+\item{n}{Number of terms of payment.}
+\item{m}{Deferring period, whose default value is zero.}
+\item{k}{Frequency of payment.}
+\item{type}{The payment type. Use \code{"immediate"} (default) for an annuity-immediate, where payments are made at the end of each period, or \code{"due"} for an annuity-due, where payments are made at the beginning of each period. For compatibility, \code{"arrears"} is an alias for \code{"immediate"} and \code{"advance"} is an alias for \code{"due"}.}
 }
-\item{n}{
-	Number of terms of payment.
-}
-\item{m}{
-	Deferring period, whose default value is zero.
-}
-\item{k}{
-	Frequency of payment.
-}
-  \item{type}{
-The Payment type, either \code{"advance"} for the annuity due (default)
-or \code{"arrears"} for the annuity immediate.
-Alternatively, one can use \code{"due"} or \code{"immediate"}
-	respectively (can be abbreviated).
-}
-}
-\details{
-	The accumulated value is the future value of the terms of an annuity. Its mathematical expression is \eqn{s_{\left. {\overline {\, n \,}}\! \right| } = 
-	\left( {1 + i} \right)^n a_{\left. {\overline {\, n \,}}\! \right| }}
-}
-\value{
-	A numeric value representing the calculated accumulated value.
-}
-\references{
-	Broverman, S.A., Mathematics of Investment and Credit (Fourth Edition), 
-	2008, ACTEX Publications.
-}
-\author{
-	Giorgio A. Spedicato
-}
-\note{
-	Accumulated value are derived from annuities by the following basic 
-	equation \eqn{{s_{\left. {\overline {\, 
- n \,}}\! \right| }} = {\left( {1 + i} \right)^n} = a_{\left. {\overline {\, 
- n \,}}\! \right| }}.
-}
-
-
-\section{Warning }{
-	The function is provided as is, without any guarantee regarding the accuracy of calculation. We disclaim any liability for eventual 
-	losses arising from direct or indirect use of this software.
-}
-
-\seealso{
-\code{\link{annuity}}
-}
+\details{The accumulated value is the future value of the terms of an annuity. Its mathematical expression is \eqn{s_{\left. {\overline {\, n \,}}\! \right| } = \left( {1 + i} \right)^n a_{\left. {\overline {\, n \,}}\! \right| }}. The payment timing follows the \code{type} argument: an annuity-immediate has payments at the end of each period, while an annuity-due has payments at the beginning of each period.}
+\value{A numeric value representing the calculated accumulated value.}
+\references{Broverman, S.A., Mathematics of Investment and Credit (Fourth Edition), 2008, ACTEX Publications.}
+\author{Giorgio A. Spedicato}
+\note{Accumulated values are derived from annuities by the standard accumulation relationship.}
+\section{Warning }{The function is provided as is, without any guarantee regarding the accuracy of calculation. We disclaim any liability for eventual losses arising from direct or indirect use of this software.}
+\seealso{\code{\link{annuity}}}
 \examples{
-#A man wants to save 100,000 to pay for his sons
-#education in 10 years time. An education fund requires the investors to
-#deposit equal installments annually at the end of each year. If interest of
-#0.075 is paid, how much does the man need to save each year in order to
-#meet his target?
+# A man wants to save 100,000 to pay for his sons
+# education in 10 years time. An education fund requires the investor to
+# deposit equal installments annually at the end of each year. If interest of
+# 0.075 is paid, how much does the man need to save each year in order to
+# meet his target?
 R=100000/accumulatedValue(i=0.075,n=10)
 
 }
-
-

--- a/man/accumulatedValue.Rd
+++ b/man/accumulatedValue.Rd
@@ -1,29 +1,78 @@
 \name{accumulatedValue}
 \alias{accumulatedValue}
 
-\title{Function to evaluate the accumulated value.}
-\description{This functions returns the value at time n of a series of equally spaced payments of 1.}
-\usage{accumulatedValue(i, n,m=0, k,type = "immediate")}
-\arguments{
-\item{i}{Effective interest rate expressed in decimal form. E.g. 0.03 means 3\%.}
-\item{n}{Number of terms of payment.}
-\item{m}{Deferring period, whose default value is zero.}
-\item{k}{Frequency of payment.}
-\item{type}{The payment type. Use \code{"immediate"} (default) for an annuity-immediate, where payments are made at the end of each period, or \code{"due"} for an annuity-due, where payments are made at the beginning of each period. For compatibility, \code{"arrears"} is an alias for \code{"immediate"} and \code{"advance"} is an alias for \code{"due"}.}
+\title{
+	Function to evaluate the accumulated value.
 }
-\details{The accumulated value is the future value of the terms of an annuity. Its mathematical expression is \eqn{s_{\left. {\overline {\, n \,}}\! \right| } = \left( {1 + i} \right)^n a_{\left. {\overline {\, n \,}}\! \right| }}. The payment timing follows the \code{type} argument: an annuity-immediate has payments at the end of each period, while an annuity-due has payments at the beginning of each period.}
-\value{A numeric value representing the calculated accumulated value.}
-\references{Broverman, S.A., Mathematics of Investment and Credit (Fourth Edition), 2008, ACTEX Publications.}
-\author{Giorgio A. Spedicato}
-\note{Accumulated values are derived from annuities by the standard accumulation relationship.}
-\section{Warning }{The function is provided as is, without any guarantee regarding the accuracy of calculation. We disclaim any liability for eventual losses arising from direct or indirect use of this software.}
-\seealso{\code{\link{annuity}}}
+\description{
+	This functions returns the value at time n of a series of equally spaced payments of 1.
+}
+\usage{
+	accumulatedValue(i, n,m=0, k,type = "immediate")
+}
+
+\arguments{
+\item{i}{
+	Effective interest rate expressed in decimal form. E.g. 0.03 means 3\%.
+}
+\item{n}{
+	Number of terms of payment.
+}
+\item{m}{
+	Deferring period, whose default value is zero.
+}
+\item{k}{
+	Frequency of payment.
+}
+  \item{type}{
+The payment type. Use \code{"immediate"} (default) for an annuity-immediate,
+where payments are made at the end of each period, or \code{"due"} for an
+annuity-due, where payments are made at the beginning of each period.
+For compatibility, \code{"arrears"} is an alias for \code{"immediate"} and
+\code{"advance"} is an alias for \code{"due"} (can be abbreviated).
+}
+}
+\details{
+	The accumulated value is the future value of the terms of an annuity. Its mathematical expression is \eqn{s_{\left. {\overline {\, n \,}}\! \right| } = 
+	\left( {1 + i} \right)^n a_{\left. {\overline {\, n \,}}\! \right| }}
+	The payment timing follows the \code{type} argument: an annuity-immediate
+	has payments at the end of each period, while an annuity-due has payments
+	at the beginning of each period.
+}
+\value{
+	A numeric value representing the calculated accumulated value.
+}
+\references{
+	Broverman, S.A., Mathematics of Investment and Credit (Fourth Edition), 
+	2008, ACTEX Publications.
+}
+\author{
+	Giorgio A. Spedicato
+}
+\note{
+	Accumulated value are derived from annuities by the following basic 
+	equation \eqn{{s_{\left. {\overline {\, 
+ n \,}}\! \right| }} = {\left( {1 + i} \right)^n} = a_{\left. {\overline {\, 
+ n \,}}\! \right| }}.
+}
+
+
+\section{Warning }{
+	The function is provided as is, without any guarantee regarding the accuracy of calculation. We disclaim any liability for eventual 
+	losses arising from direct or indirect use of this software.
+}
+
+\seealso{
+\code{\link{annuity}}
+}
 \examples{
-# A man wants to save 100,000 to pay for his sons
-# education in 10 years time. An education fund requires the investor to
-# deposit equal installments annually at the end of each year. If interest of
-# 0.075 is paid, how much does the man need to save each year in order to
-# meet his target?
+#A man wants to save 100,000 to pay for his sons
+#education in 10 years time. An education fund requires the investors to
+#deposit equal installments annually at the end of each year. If interest of
+#0.075 is paid, how much does the man need to save each year in order to
+#meet his target?
 R=100000/accumulatedValue(i=0.075,n=10)
 
 }
+
+

--- a/man/annuity.Rd
+++ b/man/annuity.Rd
@@ -26,19 +26,23 @@ annuity(i, n, m = 0, k = 1, type = "immediate")
 	supposed to be performed at the end of each year.
 }
   \item{type}{
-The Payment type, either \code{"advance"} for the annuity due (default)
-or \code{"arrears"} for the annuity immediate.
-Alternatively, one can use \code{"due"} or \code{"immediate"}
-	respectively (can be abbreviated).
+The payment type. Use \code{"immediate"} (default) for an annuity-immediate,
+where payments are made at the end of each period, or \code{"due"} for an
+annuity-due, where payments are made at the beginning of each period.
+For compatibility, \code{"arrears"} is an alias for \code{"immediate"} and
+\code{"advance"} is an alias for \code{"due"} (can be abbreviated).
 }
 }
 \details{
 	This function calculates the present value of a stream of fixed payments 
-	separated by equal interval of time. Annuity immediate has the 
-	fist payment at time t = 0, while an annuity due has the first payment at time t = 1.
+	separated by equal interval of time. For an annuity-immediate the first
+	payment occurs at time \eqn{1/k}; for an annuity-due the first payment
+	occurs at time \eqn{0}. Thus, for annual payments, an annuity-immediate
+	has payment times \eqn{1,2,\\ldots,n}, whereas an annuity-due has
+	payment times \eqn{0,1,\\ldots,n-1}.
 }
 \value{
-	A string, either "immediate" or "due".
+	A numeric value representing the present value of the annuity.
 }
 \references{
 	Broverman, S.A., Mathematics of Investment and Credit (Fourth Edition), 

--- a/man/decreasingAnnuity.Rd
+++ b/man/decreasingAnnuity.Rd
@@ -1,61 +1,26 @@
 \name{decreasingAnnuity}
 \alias{decreasingAnnuity}
 
-\title{
-	Function to evaluate decreasing annuities.
-}
-\description{
-	This function return present values for decreasing annuities - certain.
-}
-\usage{
-decreasingAnnuity(i, n,type="immediate")
-}
-
+\title{Function to evaluate decreasing annuities.}
+\description{This function returns present values for decreasing annuities-certain.}
+\usage{decreasingAnnuity(i, n,type="immediate")}
 \arguments{
-  \item{i}{
-	A numeric value representing the interest rate.
+  \item{i}{A numeric value representing the interest rate.}
+  \item{n}{The number of periods.}
+  \item{type}{The payment type. Use \code{"immediate"} (default) for an annuity-immediate, where payments are made at the end of each period, or \code{"due"} for an annuity-due, where payments are made at the beginning of each period. For compatibility, \code{"arrears"} is an alias for \code{"immediate"} and \code{"advance"} is an alias for \code{"due"}.}
 }
-  \item{n}{
-	The number of periods.
-}
-  \item{type}{
-The Payment type, either \code{"advance"} for the annuity due (default)
-or \code{"arrears"} for the annuity immediate.
-Alternatively, one can use \code{"due"} or \code{"immediate"}
-	respectively (can be abbreviated).
-}
-}
-\details{
-	A decreasing annuity has the following flows of payments: n, n-1, n-2, \ldots, 1, 0.
-}
-\value{
-	A numeric value reporting the present value of the decreasing cash flows.
-}
-\references{
-Broverman, S.A., Mathematics of Investment and Credit (Fourth Edition), 
-	2008, ACTEX Publications.
-}
-\author{
-	Giorgio A. Spedicato
-}
-\note{
-	This function calls \code{presentValue} function internally.
-}
-
-\section{Warning }{
-	The function is provided as is, without any guarantee regarding the accuracy of calculation. The author disclaims any liability for eventual 
-	losses arising from direct or indirect use of this software.
-}
-
-\seealso{
-\code{\link{annuity}},\code{\link{increasingAnnuity}},\code{\link{DAxn}}
-}
+\details{A decreasing annuity has the following flows of payments: \eqn{n,n-1,n-2,\\ldots,1}. For an annuity-immediate these payments occur at times \eqn{1,2,\\ldots,n}; for an annuity-due they occur at times \eqn{0,1,\\ldots,n-1}.}
+\value{A numeric value reporting the present value of the decreasing cash flows.}
+\references{Broverman, S.A., Mathematics of Investment and Credit (Fourth Edition), 2008, ACTEX Publications.}
+\author{Giorgio A. Spedicato}
+\note{This function calls \code{presentValue} function internally.}
+\section{Warning }{The function is provided as is, without any guarantee regarding the accuracy of calculation. We disclaim any liability for eventual losses arising from direct or indirect use of this software.}
+\seealso{\code{\link{annuity}},\code{\link{increasingAnnuity}},\code{\link{DAxn}}}
 \examples{
-	#the present value of 10, 9, 8,....,0 payable at the end of the period
-	#for 10 years is
-	decreasingAnnuity(i=0.03, n=10)
-	#assuming a 3% interest rate
-	#should be
-	sum((10:1)/(1+.03)^(1:10))
+# the present value of 10, 9, 8,....,1 payable at the end of the period
+# for 10 years is
+decreasingAnnuity(i=0.03, n=10)
+# assuming a 3% interest rate
+# should be
+sum((10:1)/(1+.03)^(1:10))
 }
-

--- a/man/decreasingAnnuity.Rd
+++ b/man/decreasingAnnuity.Rd
@@ -1,26 +1,64 @@
 \name{decreasingAnnuity}
 \alias{decreasingAnnuity}
 
-\title{Function to evaluate decreasing annuities.}
-\description{This function returns present values for decreasing annuities-certain.}
-\usage{decreasingAnnuity(i, n,type="immediate")}
+\title{
+	Function to evaluate decreasing annuities.
+}
+\description{
+	This function return present values for decreasing annuities - certain.
+}
+\usage{
+decreasingAnnuity(i, n,type="immediate")
+}
+
 \arguments{
-  \item{i}{A numeric value representing the interest rate.}
-  \item{n}{The number of periods.}
-  \item{type}{The payment type. Use \code{"immediate"} (default) for an annuity-immediate, where payments are made at the end of each period, or \code{"due"} for an annuity-due, where payments are made at the beginning of each period. For compatibility, \code{"arrears"} is an alias for \code{"immediate"} and \code{"advance"} is an alias for \code{"due"}.}
+  \item{i}{
+	A numeric value representing the interest rate.
 }
-\details{A decreasing annuity has the following flows of payments: \eqn{n,n-1,n-2,\\ldots,1}. For an annuity-immediate these payments occur at times \eqn{1,2,\\ldots,n}; for an annuity-due they occur at times \eqn{0,1,\\ldots,n-1}.}
-\value{A numeric value reporting the present value of the decreasing cash flows.}
-\references{Broverman, S.A., Mathematics of Investment and Credit (Fourth Edition), 2008, ACTEX Publications.}
-\author{Giorgio A. Spedicato}
-\note{This function calls \code{presentValue} function internally.}
-\section{Warning }{The function is provided as is, without any guarantee regarding the accuracy of calculation. We disclaim any liability for eventual losses arising from direct or indirect use of this software.}
-\seealso{\code{\link{annuity}},\code{\link{increasingAnnuity}},\code{\link{DAxn}}}
+  \item{n}{
+	The number of periods.
+}
+  \item{type}{
+The payment type. Use \code{"immediate"} (default) for an annuity-immediate,
+where payments are made at the end of each period, or \code{"due"} for an
+annuity-due, where payments are made at the beginning of each period.
+For compatibility, \code{"arrears"} is an alias for \code{"immediate"} and
+\code{"advance"} is an alias for \code{"due"} (can be abbreviated).
+}
+}
+\details{
+	A decreasing annuity has the following flows of payments: n, n-1, n-2, \ldots, 1, 0.
+	For an annuity-immediate these payments occur at times \eqn{1,2,\ldots,n};
+	for an annuity-due they occur at times \eqn{0,1,\ldots,n-1}.
+}
+\value{
+	A numeric value reporting the present value of the decreasing cash flows.
+}
+\references{
+Broverman, S.A., Mathematics of Investment and Credit (Fourth Edition), 
+	2008, ACTEX Publications.
+}
+\author{
+	Giorgio A. Spedicato
+}
+\note{
+	This function calls \code{presentValue} function internally.
+}
+
+\section{Warning }{
+	The function is provided as is, without any guarantee regarding the accuracy of calculation. The author disclaims any liability for eventual 
+	losses arising from direct or indirect use of this software.
+}
+
+\seealso{
+\code{\link{annuity}},\code{\link{increasingAnnuity}},\code{\link{DAxn}}
+}
 \examples{
-# the present value of 10, 9, 8,....,1 payable at the end of the period
-# for 10 years is
-decreasingAnnuity(i=0.03, n=10)
-# assuming a 3% interest rate
-# should be
-sum((10:1)/(1+.03)^(1:10))
+	#the present value of 10, 9, 8,....,0 payable at the end of the period
+	#for 10 years is
+	decreasingAnnuity(i=0.03, n=10)
+	#assuming a 3% interest rate
+	#should be
+	sum((10:1)/(1+.03)^(1:10))
 }
+

--- a/man/increasingAnnuity.Rd
+++ b/man/increasingAnnuity.Rd
@@ -1,25 +1,63 @@
 \name{increasingAnnuity}
 \alias{increasingAnnuity}
 
-\title{Increasing annuity.}
-\description{This function evaluates non-stochastic increasing annuities.}
-\usage{increasingAnnuity(i, n, type = "immediate")}
+\title{
+	Increasing annuity.
+}
+\description{
+	This function evaluates non - stochastic increasing annuities.
+}
+\usage{
+	increasingAnnuity(i, n, type = "immediate")
+}
+
 \arguments{
-\item{i}{A numeric value representing the interest rate.}
-\item{n}{The number of periods.}
-\item{type}{The payment type. Use \code{"immediate"} (default) for an annuity-immediate, where payments are made at the end of each period, or \code{"due"} for an annuity-due, where payments are made at the beginning of each period. For compatibility, \code{"arrears"} is an alias for \code{"immediate"} and \code{"advance"} is an alias for \code{"due"}.}
+  \item{i}{
+	A numeric value representing the interest rate.
 }
-\details{An increasing annuity shows the following flow of payments: \eqn{1,2,\\ldots,n-1,n}. For an annuity-immediate these payments occur at times \eqn{1,2,\\ldots,n}; for an annuity-due they occur at times \eqn{0,1,\\ldots,n-1}.}
-\value{The value of the annuity.}
-\references{Broverman, S.A., Mathematics of Investment and Credit (Fourth Edition), 2008, ACTEX Publications.}
-\author{Giorgio A. Spedicato}
-\note{This function calls internally \code{presentValue} function.}
-\section{Warning }{The function is provided as is, without any guarantee regarding the accuracy of calculation. We disclaim any liability for eventual losses arising from direct or indirect use of this software.}
-\seealso{\code{\link{decreasingAnnuity}},\code{\link{IAxn}}}
+  \item{n}{
+	The number of periods.
+}
+  \item{type}{
+The payment type. Use \code{"immediate"} (default) for an annuity-immediate,
+where payments are made at the end of each period, or \code{"due"} for an
+annuity-due, where payments are made at the beginning of each period.
+For compatibility, \code{"arrears"} is an alias for \code{"immediate"} and
+\code{"advance"} is an alias for \code{"due"} (can be abbreviated).
+}
+}
+\details{
+	An increasing annuity shows the following flow of payments: \eqn{1,2,\ldots,n-1,n}.
+	For an annuity-immediate these payments occur at times \eqn{1,2,\ldots,n};
+	for an annuity-due they occur at times \eqn{0,1,\ldots,n-1}.
+}
+\value{
+	The value of the annuity.
+}
+\references{
+Broverman, S.A., Mathematics of Investment and Credit (Fourth Edition), 
+	2008, ACTEX Publications.
+}
+\author{
+	Giorgio A. Spedicato
+}
+\note{
+	This function calls internally \code{presentValue} function.
+}
+
+\section{Warning }{
+	The function is provided as is, without any guarantee regarding the accuracy of calculation. We disclaim any liability for eventual 
+	losses arising from direct or indirect use of this software.
+}
+
+\seealso{
+\code{\link{decreasingAnnuity}},\code{\link{IAxn}}
+}
 \examples{
-# the present value of 1,2,...,n-1,n sequence of payments,
-# payable at the end of the period
-# for 10 periods is
-increasingAnnuity(i=0.03, n=10)
-# assuming a 3% interest rate
+	#the present value of 1,2,...,n-1, n sequence of payments, 
+	#payable at the end of the period
+	#for 10 periods is
+	increasingAnnuity(i=0.03, n=10)
+	#assuming a 3% interest rate
 }
+

--- a/man/increasingAnnuity.Rd
+++ b/man/increasingAnnuity.Rd
@@ -1,60 +1,25 @@
 \name{increasingAnnuity}
 \alias{increasingAnnuity}
 
-\title{
-	Increasing annuity.
-}
-\description{
-	This function evaluates non - stochastic increasing annuities.
-}
-\usage{
-	increasingAnnuity(i, n, type = "immediate")
-}
-
+\title{Increasing annuity.}
+\description{This function evaluates non-stochastic increasing annuities.}
+\usage{increasingAnnuity(i, n, type = "immediate")}
 \arguments{
-  \item{i}{
-	A numeric value representing the interest rate.
+\item{i}{A numeric value representing the interest rate.}
+\item{n}{The number of periods.}
+\item{type}{The payment type. Use \code{"immediate"} (default) for an annuity-immediate, where payments are made at the end of each period, or \code{"due"} for an annuity-due, where payments are made at the beginning of each period. For compatibility, \code{"arrears"} is an alias for \code{"immediate"} and \code{"advance"} is an alias for \code{"due"}.}
 }
-  \item{n}{
-	The number of periods.
-}
-  \item{type}{
-The Payment type, either \code{"advance"} for the annuity due (default)
-or \code{"arrears"} for the annuity immediate.
-Alternatively, one can use \code{"due"} or \code{"immediate"}
-	respectively (can be abbreviated).
-}
-}
-\details{
-	An increasing annuity shows the following flow of payments: \eqn{1,2,\ldots,n-1,n}
-}
-\value{
-	The value of the annuity.
-}
-\references{
-Broverman, S.A., Mathematics of Investment and Credit (Fourth Edition), 
-	2008, ACTEX Publications.
-}
-\author{
-	Giorgio A. Spedicato
-}
-\note{
-	This function calls internally \code{presentValue} function.
-}
-
-\section{Warning }{
-	The function is provided as is, without any guarantee regarding the accuracy of calculation. We disclaim any liability for eventual 
-	losses arising from direct or indirect use of this software.
-}
-
-\seealso{
-\code{\link{decreasingAnnuity}},\code{\link{IAxn}}
-}
+\details{An increasing annuity shows the following flow of payments: \eqn{1,2,\\ldots,n-1,n}. For an annuity-immediate these payments occur at times \eqn{1,2,\\ldots,n}; for an annuity-due they occur at times \eqn{0,1,\\ldots,n-1}.}
+\value{The value of the annuity.}
+\references{Broverman, S.A., Mathematics of Investment and Credit (Fourth Edition), 2008, ACTEX Publications.}
+\author{Giorgio A. Spedicato}
+\note{This function calls internally \code{presentValue} function.}
+\section{Warning }{The function is provided as is, without any guarantee regarding the accuracy of calculation. We disclaim any liability for eventual losses arising from direct or indirect use of this software.}
+\seealso{\code{\link{decreasingAnnuity}},\code{\link{IAxn}}}
 \examples{
-	#the present value of 1,2,...,n-1, n sequence of payments, 
-	#payable at the end of the period
-	#for 10 periods is
-	increasingAnnuity(i=0.03, n=10)
-	#assuming a 3% interest rate
+# the present value of 1,2,...,n-1,n sequence of payments,
+# payable at the end of the period
+# for 10 periods is
+increasingAnnuity(i=0.03, n=10)
+# assuming a 3% interest rate
 }
-

--- a/tests/testthat/testFinancialMathematics.R
+++ b/tests/testthat/testFinancialMathematics.R
@@ -6,6 +6,23 @@ test_that("Annuities", {
   expect_equal(round(decreasingAnnuity(i = 0.03,n = 10,type = "due")*10,2), 504.63) #BOWERS P 339
 })
 
+test_that("Annuity immediate and due use standard payment timing", {
+  i <- 0.03
+  n <- 10
+
+  immediate <- annuity(i = i, n = n, type = "immediate")
+  due <- annuity(i = i, n = n, type = "due")
+
+  # annuity-immediate pays at t = 1,...,n; annuity-due at t = 0,...,n-1
+  expect_equal(immediate, sum((1 / (1 + i))^(1:n)), tolerance = 1e-12)
+  expect_equal(due, sum((1 / (1 + i))^(0:(n - 1))), tolerance = 1e-12)
+  expect_equal(due, (1 + i) * immediate, tolerance = 1e-12)
+
+  # Backward-compatible aliases must retain the same semantics.
+  expect_equal(annuity(i = i, n = n, type = "arrears"), immediate, tolerance = 1e-12)
+  expect_equal(annuity(i = i, n = n, type = "advance"), due, tolerance = 1e-12)
+})
+
 #TODO: ADD DURATION CHECKS
 
 ex_time = seq(1,6)


### PR DESCRIPTION
## Summary
- correct the documentation of `annuity-immediate` and `annuity-due` payment timing
- document `immediate` as the default and `due` as the beginning-of-period convention
- clarify the compatibility aliases `arrears` and `advance`
- add regression tests for payment timing and the standard due/immediate relationship

## Why
The implementation already uses the standard actuarial convention: `immediate` pays at times 1, ..., n and `due` at 0, ..., n-1. Several Rd files nevertheless described these conventions inconsistently, including an explicit inversion of the definitions.

This PR fixes the terminology without changing the numerical implementation.

Closes #19