### PR TITLE
Fix annuity terminology, based on current main

### DIFF
--- a/man/accumulatedValue.Rd
+++ b/man/accumulatedValue.Rd
@@ -2,60 +2,64 @@
 \alias{accumulatedValue}
 
 \title{
-	Function to evaluate the accumulated value.
+\tFunction to evaluate the accumulated value.
 }
 \description{
-	This functions returns the value at time n of a series of equally spaced payments of 1.
+\tThis functions returns the value at time n of a series of equally spaced payments of 1.
 }
 \usage{
-	accumulatedValue(i, n,m=0, k,type = "immediate")
+\taccumulatedValue(i, n,m=0, k,type = "immediate")
 }
 
 \arguments{
 \item{i}{
-	Effective interest rate expressed in decimal form. E.g. 0.03 means 3\%.
+\tEffective interest rate expressed in decimal form. E.g. 0.03 means 3\%.
 }
 \item{n}{
-	Number of terms of payment.
+\tNumber of terms of payment.
 }
 \item{m}{
-	Deferring period, whose default value is zero.
+\tDeferring period, whose default value is zero.
 }
 \item{k}{
-	Frequency of payment.
+\tFrequency of payment.
 }
   \item{type}{
-The Payment type, either \code{"advance"} for the annuity due (default)
-or \code{"arrears"} for the annuity immediate.
-Alternatively, one can use \code{"due"} or \code{"immediate"}
-	respectively (can be abbreviated).
+The payment type. Use \code{"immediate"} (default) for an annuity-immediate,
+where payments are made at the end of each period, or \code{"due"} for an
+annuity-due, where payments are made at the beginning of each period.
+For compatibility, \code{"arrears"} is an alias for \code{"immediate"} and
+\code{"advance"} is an alias for \code{"due"} (can be abbreviated).
 }
 }
 \details{
-	The accumulated value is the future value of the terms of an annuity. Its mathematical expression is \eqn{s_{\left. {\overline {\, n \,}}\! \right| } = 
-	\left( {1 + i} \right)^n a_{\left. {\overline {\, n \,}}\! \right| }}
+\tThe accumulated value is the future value of the terms of an annuity. Its mathematical expression is \eqn{s_{\left. {\overline {\, n \,}}\! \right| } = 
+\t\left( {1 + i} \right)^n a_{\left. {\overline {\, n \,}}\! \right| }}
+\tThe payment timing follows the \code{type} argument: an annuity-immediate
+\thas payments at the end of each period, while an annuity-due has payments
+\tat the beginning of each period.
 }
 \value{
-	A numeric value representing the calculated accumulated value.
+\tA numeric value representing the calculated accumulated value.
 }
 \references{
-	Broverman, S.A., Mathematics of Investment and Credit (Fourth Edition), 
-	2008, ACTEX Publications.
+\tBroverman, S.A., Mathematics of Investment and Credit (Fourth Edition), 
+\t2008, ACTEX Publications.
 }
 \author{
-	Giorgio A. Spedicato
+\tGiorgio A. Spedicato
 }
 \note{
-	Accumulated value are derived from annuities by the following basic 
-	equation \eqn{{s_{\left. {\overline {\, 
+\tAccumulated value are derived from annuities by the following basic 
+\tequation \eqn{{s_{\left. {\overline {\, 
  n \,}}\! \right| }} = {\left( {1 + i} \right)^n} = a_{\left. {\overline {\, 
  n \,}}\! \right| }}.
 }
 
 
 \section{Warning }{
-	The function is provided as is, without any guarantee regarding the accuracy of calculation. We disclaim any liability for eventual 
-	losses arising from direct or indirect use of this software.
+\tThe function is provided as is, without any guarantee regarding the accuracy of calculation. We disclaim any liability for eventual 
+\tlosses arising from direct or indirect use of this software.
 }
 
 \seealso{

--- a/man/annuity.Rd
+++ b/man/annuity.Rd
@@ -12,44 +12,48 @@ annuity(i, n, m = 0, k = 1, type = "immediate")
 
 \arguments{
 \item{i}{
-	Effective interest rate expressed in decimal form. E.g. 0.03 means 3\%. It can be a vector of interest rates of the same length
-	of periods. 
+\tEffective interest rate expressed in decimal form. E.g. 0.03 means 3\%. It can be a vector of interest rates of the same length
+\tof periods. 
 }
 \item{n}{
-	Periods for payments. If n = \code{infinity} then \code{annuity} returns the value of a perpetuity (either immediate or due). 
+\tPeriods for payments. If n = \code{infinity} then \code{annuity} returns the value of a perpetuity (either immediate or due). 
 }
 \item{m}{
-	Deferring period, whose default value is zero.
+\tDeferring period, whose default value is zero.
 }
 \item{k}{
-	Yearly payments frequency. A payment of \eqn{k^-1} is 
-	supposed to be performed at the end of each year.
+\tYearly payments frequency. A payment of \eqn{k^-1} is 
+\tsupposed to be performed at the end of each year.
 }
   \item{type}{
-The Payment type, either \code{"advance"} for the annuity due (default)
-or \code{"arrears"} for the annuity immediate.
-Alternatively, one can use \code{"due"} or \code{"immediate"}
-	respectively (can be abbreviated).
+The payment type. Use \code{"immediate"} (default) for an annuity-immediate,
+where payments are made at the end of each period, or \code{"due"} for an
+annuity-due, where payments are made at the beginning of each period.
+For compatibility, \code{"arrears"} is an alias for \code{"immediate"} and
+\code{"advance"} is an alias for \code{"due"} (can be abbreviated).
 }
 }
 \details{
-	This function calculates the present value of a stream of fixed payments 
-	separated by equal interval of time. Annuity immediate has the 
-	fist payment at time t = 0, while an annuity due has the first payment at time t = 1.
+\tThis function calculates the present value of a stream of fixed payments 
+\tseparated by equal interval of time. For an annuity-immediate the first
+\tpayment occurs at time \eqn{1/k}; for an annuity-due the first payment
+\toccur at time \eqn{0}. Thus, for annual payments, an annuity-immediate
+\thas payment times \eqn{1,2,\\ldots,n}, whereas an annuity-due has
+\tpayment times \eqn{0,1,\\ldots,n-1}.
 }
 \value{
-	A string, either "immediate" or "due".
+\tA numeric value representing the present value of the annuity.
 }
 \references{
-	Broverman, S.A., Mathematics of Investment and Credit (Fourth Edition), 
-	2008, ACTEX Publications.
+\tBroverman, S.A., Mathematics of Investment and Credit (Fourth Edition), 
+\t2008, ACTEX Publications.
 }
 \author{
-	Giorgio A. Spedicato
+\tGiorgio A. Spedicato
 }
 \note{
-	The value returned by annuity function derives from direct calculation of the discounted cash flow and 
-	not from formulas, like \eqn{{a^{\left( m \right)}}_{\left. {\overline {\, 
+\tThe value returned by annuity function derives from direct calculation of the discounted cash flow and 
+\tnot from formulas, like \eqn{{a^{\left( m \right)}}_{\left. {\overline {\, 
  n \,}}\! \right| } = \frac{{1 - {v^n}}}{{{i^{\left( m \right)}}}}}. When m is greater than 
  1, the payment per period is assumed to be \eqn{\frac{1}{m}}.
 }

--- a/man/decreasingAnnuity.Rd
+++ b/man/decreasingAnnuity.Rd
@@ -2,10 +2,10 @@
 \alias{decreasingAnnuity}
 
 \title{
-	Function to evaluate decreasing annuities.
+\tFunction to evaluate decreasing annuities.
 }
 \description{
-	This function return present values for decreasing annuities - certain.
+\tThis function return present values for decreasing annuities - certain.
 }
 \usage{
 decreasingAnnuity(i, n,type="immediate")
@@ -13,49 +13,52 @@ decreasingAnnuity(i, n,type="immediate")
 
 \arguments{
   \item{i}{
-	A numeric value representing the interest rate.
+\tA numeric value representing the interest rate.
 }
   \item{n}{
-	The number of periods.
+\tThe number of periods.
 }
   \item{type}{
-The Payment type, either \code{"advance"} for the annuity due (default)
-or \code{"arrears"} for the annuity immediate.
-Alternatively, one can use \code{"due"} or \code{"immediate"}
-	respectively (can be abbreviated).
+The payment type. Use \code{"immediate"} (default) for an annuity-immediate,
+where payments are made at the end of each period, or \code{"due"} for an
+annuity-due, where payments are made at the beginning of each period.
+For compatibility, \code{"arrears"} is an alias for \code{"immediate"} and
+\code{"advance"} is an alias for \code{"due"} (can be abbreviated).
 }
 }
 \details{
-	A decreasing annuity has the following flows of payments: n, n-1, n-2, \ldots, 1, 0.
+\tA decreasing annuity has the following flows of payments: n, n-1, n-2, \ldots, 1, 0.
+\tFor an annuity-immediate these payments occur at times \eqn{1,2,\ldots,n};
+\tfor an annuity-due they occur at times \eqn{0,1,\ldots,n-1}.
 }
 \value{
-	A numeric value reporting the present value of the decreasing cash flows.
+\tA numeric value reporting the present value of the decreasing cash flows.
 }
 \references{
 Broverman, S.A., Mathematics of Investment and Credit (Fourth Edition), 
-	2008, ACTEX Publications.
+\t2008, ACTEX Publications.
 }
 \author{
-	Giorgio A. Spedicato
+\tGiorgio A. Spedicato
 }
 \note{
-	This function calls \code{presentValue} function internally.
+\tThis function calls \code{presentValue} function internally.
 }
 
 \section{Warning }{
-	The function is provided as is, without any guarantee regarding the accuracy of calculation. The author disclaims any liability for eventual 
-	losses arising from direct or indirect use of this software.
+\tThe function is provided as is, without any guarantee regarding the accuracy of calculation. The author disclaims any liability for eventual 
+\tlosses arising from direct or indirect use of this software.
 }
 
 \seealso{
 \code{\link{annuity}},\code{\link{increasingAnnuity}},\code{\link{DAxn}}
 }
 \examples{
-	#the present value of 10, 9, 8,....,0 payable at the end of the period
-	#for 10 years is
-	decreasingAnnuity(i=0.03, n=10)
-	#assuming a 3% interest rate
-	#should be
-	sum((10:1)/(1+.03)^(1:10))
+\t#the present value of 10, 9, 8,....,0 payable at the end of the period
+\t#for 10 years is
+\tdecreasingAnnuity(i=0.03, n=10)
+\t#assuming a 3% interest rate
+\t#should be
+\tsum((10:1)/(1+.03)^(1:10))
 }
 

--- a/man/increasingAnnuity.Rd
+++ b/man/increasingAnnuity.Rd
@@ -2,59 +2,62 @@
 \alias{increasingAnnuity}
 
 \title{
-	Increasing annuity.
+\tIncreasing annuity.
 }
 \description{
-	This function evaluates non - stochastic increasing annuities.
+\tThis function evaluates non - stochastic increasing annuities.
 }
 \usage{
-	increasingAnnuity(i, n, type = "immediate")
+\tincreasingAnnuity(i, n, type = "immediate")
 }
 
 \arguments{
   \item{i}{
-	A numeric value representing the interest rate.
+\tA numeric value representing the interest rate.
 }
   \item{n}{
-	The number of periods.
+\tThe number of periods.
 }
   \item{type}{
-The Payment type, either \code{"advance"} for the annuity due (default)
-or \code{"arrears"} for the annuity immediate.
-Alternatively, one can use \code{"due"} or \code{"immediate"}
-	respectively (can be abbreviated).
+The payment type. Use \code{"immediate"} (default) for an annuity-immediate,
+where payments are made at the end of each period, or \code{"due"} for an
+annuity-due, where payments are made at the beginning of each period.
+For compatibility, \code{"arrears"} is an alias for \code{"immediate"} and
+\code{"advance"} is an alias for \code{"due"} (can be abbreviated).
 }
 }
 \details{
-	An increasing annuity shows the following flow of payments: \eqn{1,2,\ldots,n-1,n}
+\tAn increasing annuity shows the following flow of payments: \eqn{1,2,\ldots,n-1,n}.
+\tFor an annuity-immediate these payments occur at times \eqn{1,2,\ldots,n};
+\tfor an annuity-due they occur at times \eqn{0,1,\ldots,n-1}.
 }
 \value{
-	The value of the annuity.
+\tThe value of the annuity.
 }
 \references{
 Broverman, S.A., Mathematics of Investment and Credit (Fourth Edition), 
-	2008, ACTEX Publications.
+\t2008, ACTEX Publications.
 }
 \author{
-	Giorgio A. Spedicato
+\tGiorgio A. Spedicato
 }
 \note{
-	This function calls internally \code{presentValue} function.
+\tThis function calls internally \code{presentValue} function.
 }
 
 \section{Warning }{
-	The function is provided as is, without any guarantee regarding the accuracy of calculation. We disclaim any liability for eventual 
-	losses arising from direct or indirect use of this software.
+\tThe function is provided as is, without any guarantee regarding the accuracy of calculation. We disclaim any liability for eventual 
+\tlosses arising from direct or indirect use of this software.
 }
 
 \seealso{
 \code{\link{decreasingAnnuity}},\code{\link{IAxn}}
 }
 \examples{
-	#the present value of 1,2,...,n-1, n sequence of payments, 
-	#payable at the end of the period
-	#for 10 periods is
-	increasingAnnuity(i=0.03, n=10)
-	#assuming a 3% interest rate
+\t#the present value of 1,2,...,n-1, n sequence of payments, 
+\t#payable at the end of the period
+\t#for 10 periods is
+\tincreasingAnnuity(i=0.03, n=10)
+\t#assuming a 3% interest rate
 }
 

--- a/tests/testthat/testFinancialMathematics.R
+++ b/tests/testthat/testFinancialMathematics.R
@@ -6,6 +6,23 @@ test_that("Annuities", {
   expect_equal(round(decreasingAnnuity(i = 0.03,n = 10,type = "due")*10,2), 504.63) #BOWERS P 339
 })
 
+test_that("Annuity immediate and due use standard payment timing", {
+  i <- 0.03
+  n <- 10
+
+  immediate <- annuity(i = i, n = n, type = "immediate")
+  due <- annuity(i = i, n = n, type = "due")
+
+  # annuity-immediate pays at t = 1,...,n; annuity-due at t = 0,...,n-1
+  expect_equal(immediate, sum((1 / (1 + i))^(1:n)), tolerance = 1e-12)
+  expect_equal(due, sum((1 / (1 + i))^(0:(n - 1))), tolerance = 1e-12)
+  expect_equal(due, (1 + i) * immediate, tolerance = 1e-12)
+
+  # Backward-compatible aliases must retain the same semantics.
+  expect_equal(annuity(i = i, n = n, type = "arrears"), immediate, tolerance = 1e-12)
+  expect_equal(annuity(i = i, n = n, type = "advance"), due, tolerance = 1e-12)
+})
+
 #TODO: ADD DURATION CHECKS
 
 ex_time = seq(1,6)


### PR DESCRIPTION
Rebased/recreated on top of current `master` (including the merged CI/R-devel improvements from PR #55).

- Correct annuity-immediate/due terminology in the four affected Rd files.
- Keep `advance`/`arrears` as compatibility aliases.
- Add regression tests for payment timing and `due = (1+i) * immediate`.

No numerical implementation changes.