### PR TITLE
Optimize presentValueC power branches

### DIFF
--- a/inst/benchmarks/benchmark-rcpp.R
+++ b/inst/benchmarks/benchmark-rcpp.R
@@ -1,0 +1,69 @@
+library(lifecontingencies)
+
+if (!requireNamespace("bench", quietly = TRUE)) {
+  stop("Package 'bench' is required to run this development benchmark.")
+}
+
+reference_present_value <- function(cashFlows, timeIds, interestRates,
+                                    probabilities, power = 1) {
+  v <- (1 + interestRates)^(-timeIds)
+  sum((cashFlows^power) * (v^power) * probabilities)
+}
+
+set.seed(2026)
+
+benchmark_case <- function(n, power = 1, scalar_rate = FALSE) {
+  cashFlows <- rnorm(n, mean = 100, sd = 25)
+  timeIds <- seq_len(n)
+  interestRates <- if (scalar_rate) 0.03 else runif(n, 0.01, 0.06)
+  rates_cpp <- rep(interestRates, length.out = n)
+  probabilities <- runif(n, 0.5, 1)
+
+  expected <- reference_present_value(
+    cashFlows, timeIds, interestRates, probabilities, power
+  )
+  actual <- lifecontingencies:::.presentValueC(
+    cashFlows, timeIds, rates_cpp, probabilities, power
+  )
+  stopifnot(all.equal(actual, expected, tolerance = 1e-10))
+
+  timing <- bench::mark(
+    R = reference_present_value(
+      cashFlows, timeIds, interestRates, probabilities, power
+    ),
+    Rcpp = lifecontingencies:::.presentValueC(
+      cashFlows, timeIds, rates_cpp, probabilities, power
+    ),
+    iterations = 30,
+    check = FALSE,
+    time_unit = "ms"
+  )
+
+  r_median <- as.numeric(timing$median[[1]])
+  cpp_median <- as.numeric(timing$median[[2]])
+
+  data.frame(
+    n = n,
+    power = power,
+    scalar_rate = scalar_rate,
+    iterations = 30,
+    r_median_ms = r_median,
+    cpp_median_ms = cpp_median,
+    speedup = r_median / cpp_median
+  )
+}
+
+results <- do.call(rbind, c(
+  lapply(c(100, 1000, 10000, 100000), benchmark_case, power = 1),
+  lapply(c(100, 1000, 10000, 100000), benchmark_case, power = 2),
+  lapply(c(100, 1000, 10000, 100000), benchmark_case, power = 3),
+  lapply(c(1000, 10000, 100000), benchmark_case,
+         power = 1, scalar_rate = TRUE)
+))
+
+print(results, row.names = FALSE)
+
+cat("\nSummary (n >= 10000):\n")
+summary_rows <- results[results$n >= 10000, ]
+print(summary_rows[, c("n", "power", "scalar_rate", "r_median_ms",
+                       "cpp_median_ms", "speedup")], row.names = FALSE)

--- a/src/lifecontingenciesRcpp.cpp
+++ b/src/lifecontingenciesRcpp.cpp
@@ -73,16 +73,34 @@ double presentValueC(NumericVector cashFlows,
   double total = 0.0;
   R_xlen_t n = cashFlows.size();
 
-  for (R_xlen_t i = 0; i < n; ++i) {
-    if (power == 1.0) {
-      // Common case: avoid the second pow() entirely.
+  if (power == 1.0) {
+    // Common case: no per-element branch and one pow() per observation.
+    for (R_xlen_t i = 0; i < n; ++i) {
       double discountFactor =
         std::pow(1.0 + interestRates[i], -timeIds[i]);
       total += cashFlows[i] * discountFactor * probabilities[i];
-    } else {
-      // Algebraically combine the two discounting powers into one pow().
-      // This reduces the expensive power evaluations from two to one while
-      // preserving the same mathematical expression.
+    }
+  } else if (power == 2.0) {
+    // Avoid pow() for the common integer square case.
+    for (R_xlen_t i = 0; i < n; ++i) {
+      double discountFactor =
+        std::pow(1.0 + interestRates[i], -timeIds[i] * power);
+      double cashFlow = cashFlows[i];
+      total += cashFlow * cashFlow * discountFactor * probabilities[i];
+    }
+  } else if (power == 3.0) {
+    // Avoid pow() for the common integer cube case.
+    for (R_xlen_t i = 0; i < n; ++i) {
+      double discountFactor =
+        std::pow(1.0 + interestRates[i], -timeIds[i] * power);
+      double cashFlow = cashFlows[i];
+      total += cashFlow * cashFlow * cashFlow *
+        discountFactor * probabilities[i];
+    }
+  } else {
+    // General power: preserve the mathematical formulation with one
+    // discounting pow() per observation.
+    for (R_xlen_t i = 0; i < n; ++i) {
       double discountFactor =
         std::pow(1.0 + interestRates[i], -timeIds[i] * power);
       double term = std::pow(cashFlows[i], power) *

--- a/tests/testthat/test-rcpp-backend.R
+++ b/tests/testthat/test-rcpp-backend.R
@@ -1,0 +1,37 @@
+library(testthat)
+
+reference_present_value <- function(cashFlows, timeIds, interestRates,
+                                    probabilities, power = 1) {
+  v <- (1 + interestRates)^(-timeIds)
+  sum((cashFlows^power) * (v^power) * probabilities)
+}
+
+test_that("presentValueC matches the historical R implementation", {
+  cases <- list(
+    list(c(100, -30, 50, 70), c(0, 0.5, 3, 6.25), 0.035,
+         c(1, 0.9, 0.8, 0.65), 1),
+    list(c(10, 10, 10, 10, 10, 10, 110), 1:7,
+         c(0.02, 0.021, 0.0225, 0.024, 0.0255, 0.027, 0.028),
+         rep(0.995, 7), 1),
+    list(c(3, 5, 7), c(1, 2, 3), c(0.01, 0.015, 0.02),
+         c(0.9, 0.8, 0.7), 2),
+    list(c(-3, 5, -7), c(1, 2, 3), c(0.01, 0.015, 0.02),
+         c(0.9, 0.8, 0.7), 3)
+  )
+
+  for (case in cases) {
+    names(case) <- c("cashFlows", "timeIds", "interestRates",
+                     "probabilities", "power")
+    expected <- do.call(reference_present_value, case)
+    rates <- rep(case$interestRates, length.out = length(case$timeIds))
+    case$interestRates <- rates
+    actual <- do.call(lifecontingencies:::.presentValueC, case)
+    expect_equal(actual, expected, tolerance = 1e-10)
+  }
+})
+
+test_that("presentValueC rejects incompatible lengths", {
+  expect_error(
+    lifecontingencies:::.presentValueC(c(1, 2), c(1, 2), c(0.03), c(1, 1))
+  )
+})


### PR DESCRIPTION
## Context
I re-checked the current `master` after the recent CI/CD merges. The Rcpp safety/hardening changes are present, and the one-pow discounting optimization is present, but the later `presentValueC()` optimizations from the previous round were **not** incorporated into `master`: the `power == 1` branch is still evaluated inside the hot loop, and the `power == 2/3` specializations are absent. The previous optimization branch was therefore not fully merged.

## Changes
- add testthat regression coverage comparing `.presentValueC()` with the historical R implementation;
- move the `power == 1`, `power == 2`, and `power == 3` dispatch outside the native loop;
- specialize powers 2 and 3 to multiplication, avoiding `std::pow()` on cash flows;
- preserve the general-power path and all existing validation;
- restore the reproducible development benchmark for powers 1, 2 and 3.

## Evidence
The previous benchmark showed approximately:
- power 1, n=100000: 1.87x speed-up;
- power 2, n=100000: 1.11x after the previous one-pow optimization;
- power 3, n=100000: 1.75x with the multiplication specialization.

The benchmark will be rerun against the current `master` baseline and this PR before further Rcpp kernels are changed.

## Validation
No public R API or actuarial formula is changed. Numerical equivalence is tested against the historical R implementation before performance measurements.