### PR TITLE
Optimize Rcpp hot-loop vector access

### DIFF
--- a/inst/benchmarks/benchmark-rcpp.R
+++ b/inst/benchmarks/benchmark-rcpp.R
@@ -53,7 +53,42 @@ benchmark_case <- function(n, power = 1, scalar_rate = FALSE) {
   )
 }
 
-results <- do.call(rbind, c(
+benchmark_sum_case <- function(n) {
+  x <- rnorm(n)
+  y <- rnorm(n)
+  z <- rnorm(n)
+
+  expected2 <- sum(x * y)
+  expected3 <- sum(x * y * z)
+  actual2 <- lifecontingencies:::.mult2sum(x, y)
+  actual3 <- lifecontingencies:::.mult3sum(x, y, z)
+  stopifnot(all.equal(actual2, expected2, tolerance = 1e-10))
+  stopifnot(all.equal(actual3, expected3, tolerance = 1e-10))
+
+  timing <- bench::mark(
+    R_mult2 = sum(x * y),
+    Rcpp_mult2 = lifecontingencies:::.mult2sum(x, y),
+    R_mult3 = sum(x * y * z),
+    Rcpp_mult3 = lifecontingencies:::.mult3sum(x, y, z),
+    iterations = 30,
+    check = FALSE,
+    time_unit = "ms"
+  )
+
+  data.frame(
+    n = n,
+    r_mult2_median_ms = as.numeric(timing$median[[1]]),
+    cpp_mult2_median_ms = as.numeric(timing$median[[2]]),
+    mult2_speedup = as.numeric(timing$median[[1]]) /
+      as.numeric(timing$median[[2]]),
+    r_mult3_median_ms = as.numeric(timing$median[[3]]),
+    cpp_mult3_median_ms = as.numeric(timing$median[[4]]),
+    mult3_speedup = as.numeric(timing$median[[3]]) /
+      as.numeric(timing$median[[4]])
+  )
+}
+
+present_value_results <- do.call(rbind, c(
   lapply(c(100, 1000, 10000, 100000), benchmark_case, power = 1),
   lapply(c(100, 1000, 10000, 100000), benchmark_case, power = 2),
   lapply(c(100, 1000, 10000, 100000), benchmark_case, power = 3),
@@ -61,9 +96,17 @@ results <- do.call(rbind, c(
          power = 1, scalar_rate = TRUE)
 ))
 
-print(results, row.names = FALSE)
+sum_results <- do.call(rbind, lapply(
+  c(1000, 10000, 100000), benchmark_sum_case
+))
 
-cat("\nSummary (n >= 10000):\n")
-summary_rows <- results[results$n >= 10000, ]
+cat("\nPresent-value benchmark:\n")
+print(present_value_results, row.names = FALSE)
+
+cat("\nPresent-value summary (n >= 10000):\n")
+summary_rows <- present_value_results[present_value_results$n >= 10000, ]
 print(summary_rows[, c("n", "power", "scalar_rate", "r_median_ms",
                        "cpp_median_ms", "speedup")], row.names = FALSE)
+
+cat("\nVector multiplication/sum benchmark:\n")
+print(sum_results, row.names = FALSE)

--- a/src/lifecontingenciesRcpp.cpp
+++ b/src/lifecontingenciesRcpp.cpp
@@ -37,9 +37,12 @@ double mult3sum(NumericVector x, NumericVector y, NumericVector z)
 
   double total = 0.0;
   R_xlen_t n = x.size();
+  const double* xp = REAL(x);
+  const double* yp = REAL(y);
+  const double* zp = REAL(z);
 
   for (R_xlen_t i = 0; i < n; ++i) {
-    total += x[i] * y[i] * z[i];
+    total += xp[i] * yp[i] * zp[i];
   }
   return total;
 }
@@ -51,9 +54,11 @@ double mult2sum(NumericVector x, NumericVector y)
 
   double total = 0.0;
   R_xlen_t n = x.size();
+  const double* xp = REAL(x);
+  const double* yp = REAL(y);
 
   for (R_xlen_t i = 0; i < n; ++i) {
-    total += x[i] * y[i];
+    total += xp[i] * yp[i];
   }
   return total;
 }
@@ -72,39 +77,43 @@ double presentValueC(NumericVector cashFlows,
 
   double total = 0.0;
   R_xlen_t n = cashFlows.size();
+  const double* cashFlowsPtr = REAL(cashFlows);
+  const double* timeIdsPtr = REAL(timeIds);
+  const double* interestRatesPtr = REAL(interestRates);
+  const double* probabilitiesPtr = REAL(probabilities);
 
   if (power == 1.0) {
     // Common case: no per-element branch and one pow() per observation.
     for (R_xlen_t i = 0; i < n; ++i) {
       double discountFactor =
-        std::pow(1.0 + interestRates[i], -timeIds[i]);
-      total += cashFlows[i] * discountFactor * probabilities[i];
+        std::pow(1.0 + interestRatesPtr[i], -timeIdsPtr[i]);
+      total += cashFlowsPtr[i] * discountFactor * probabilitiesPtr[i];
     }
   } else if (power == 2.0) {
     // Avoid pow() for the common integer square case.
     for (R_xlen_t i = 0; i < n; ++i) {
       double discountFactor =
-        std::pow(1.0 + interestRates[i], -timeIds[i] * power);
-      double cashFlow = cashFlows[i];
-      total += cashFlow * cashFlow * discountFactor * probabilities[i];
+        std::pow(1.0 + interestRatesPtr[i], -timeIdsPtr[i] * power);
+      double cashFlow = cashFlowsPtr[i];
+      total += cashFlow * cashFlow * discountFactor * probabilitiesPtr[i];
     }
   } else if (power == 3.0) {
     // Avoid pow() for the common integer cube case.
     for (R_xlen_t i = 0; i < n; ++i) {
       double discountFactor =
-        std::pow(1.0 + interestRates[i], -timeIds[i] * power);
-      double cashFlow = cashFlows[i];
+        std::pow(1.0 + interestRatesPtr[i], -timeIdsPtr[i] * power);
+      double cashFlow = cashFlowsPtr[i];
       total += cashFlow * cashFlow * cashFlow *
-        discountFactor * probabilities[i];
+        discountFactor * probabilitiesPtr[i];
     }
   } else {
     // General power: preserve the mathematical formulation with one
     // discounting pow() per observation.
     for (R_xlen_t i = 0; i < n; ++i) {
       double discountFactor =
-        std::pow(1.0 + interestRates[i], -timeIds[i] * power);
-      double term = std::pow(cashFlows[i], power) *
-        discountFactor * probabilities[i];
+        std::pow(1.0 + interestRatesPtr[i], -timeIdsPtr[i] * power);
+      double term = std::pow(cashFlowsPtr[i], power) *
+        discountFactor * probabilitiesPtr[i];
       total += term;
     }
   }

--- a/tests/test-rcpp-backend.R
+++ b/tests/test-rcpp-backend.R
@@ -231,6 +231,18 @@ stopifnot(all.equal(
 # -----------------------------------------------------------------------------
 # Native input validation.
 # -----------------------------------------------------------------------------
+stopifnot(all.equal(
+  lifecontingencies:::.mult2sum(c(1, 2, 3), c(4, 5, 6)),
+  sum(c(1, 2, 3) * c(4, 5, 6)),
+  tolerance = 1e-12
+))
+
+stopifnot(all.equal(
+  lifecontingencies:::.mult3sum(c(1, -2, 3), c(4, 5, -6), c(2, 3, 4)),
+  sum(c(1, -2, 3) * c(4, 5, -6) * c(2, 3, 4)),
+  tolerance = 1e-12
+))
+
 stopifnot(inherits(
   try(lifecontingencies:::.mult2sum(c(1, 2), c(1)), silent = TRUE),
   "try-error"


### PR DESCRIPTION
## Scope
Optimize Rcpp backend hot loops without changing actuarial formulas or public R behavior.

### Changes
- Use direct contiguous `REAL()` pointers in `.presentValueC()` hot loops.
- Use direct contiguous pointers in `.mult2sum()` and `.mult3sum()`.
- Add numerical regression tests for the multiplication/sum kernels.
- Extend the development benchmark to measure both present-value and multiplication/sum kernels.

### Validation strategy
- Existing Rcpp regression suite remains unchanged apart from additional equivalence checks.
- Benchmark verifies numerical equivalence before timing.
- No actuarial formula, wrapper behavior, or API is changed.

The PR should be evaluated by R release, R-devel, Windows CI, coverage, and pkgdown before merge.