### PR TITLE
Fix TinyTeX initialization for Windows vignette CI

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -14,55 +14,45 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Fast validation for pull requests: enough to catch most regressions quickly.
 jobs:
   R-CMD-check:
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
     if: github.event_name == 'pull_request'
     runs-on: ${{ matrix.config.os }}
-
     strategy:
       fail-fast: false
       matrix:
         config:
-          - { os: ubuntu-latest,  r: 'release' }
-          - { os: ubuntu-latest,  r: 'devel', http-user-agent: 'release' }
+          - { os: ubuntu-latest, r: 'release' }
+          - { os: ubuntu-latest, r: 'devel', http-user-agent: 'release' }
           - { os: windows-latest, r: 'release' }
-
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
       _R_CHECK_CRAN_INCOMING_REMOTE_: false
       _R_CHECK_LIMIT_CORES_: true
       R_CHECK_NUM_CORES: 1
-
     steps:
       - uses: actions/checkout@v7
-
       - name: Use stable Ubuntu mirror for R-devel
         if: runner.os == 'Linux' && matrix.config.r == 'devel'
         shell: bash
-        run: |
-          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.d/* 2>/dev/null || true
-
+        run: sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.d/* 2>/dev/null || true
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
-
       - name: Install system deps (Linux)
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y qpdf ghostscript
-
       - name: Install system deps (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: choco install -y ghostscript qpdf
-
       - name: Install R package dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -74,24 +64,13 @@ jobs:
           needs: check
           cache: true
           cache-version: 3
-
       - name: Setup TinyTeX
         uses: r-lib/actions/setup-tinytex@v2
-
       - name: Install LaTeX packages
         shell: Rscript {0}
         run: |
-          pkgs <- c(
-            "pict2e","grfext","everyshi","graphics","etoolbox","kvoptions","xcolor",
-            "collection-latexrecommended","collection-latexextra","collection-fontsrecommended",
-            "ae","inconsolata","upquote","courier","fancyvrb","framed","titling","booktabs",
-            "geometry","hyperref","url","microtype","graphicx","thumbpdf","float","caption",
-            "subcaption","babel-english","amsmath","amssymb","mathtools","siunitx","natbib",
-            "biblatex","csquotes","ulem","parskip","titlesec","wrapfig","longtable","makecell",
-            "multirow","colortbl","pgf","tikz","xkeyval","changepage"
-          )
+          pkgs <- c("pict2e","grfext","everyshi","graphics","etoolbox","kvoptions","xcolor","collection-latexrecommended","collection-latexextra","collection-fontsrecommended","ae","inconsolata","upquote","courier","fancyvrb","framed","titling","booktabs","geometry","hyperref","url","microtype","graphicx","thumbpdf","float","caption","subcaption","babel-english","amsmath","amssymb","mathtools","siunitx","natbib","biblatex","csquotes","ulem","parskip","titlesec","wrapfig","longtable","makecell","multirow","colortbl","pgf","tikz","xkeyval","changepage")
           if (Sys.which("tlmgr") != "") tinytex::tlmgr_install(pkgs, .quiet = TRUE)
-
       - name: Check package
         if: runner.os != 'Windows'
         uses: r-lib/actions/check-r-package@v2
@@ -100,7 +79,6 @@ jobs:
           build_args: 'c("--no-resave-data","--compact-vignettes=both")'
           args: 'c("--as-cran")'
           error-on: '"error"'
-
       - name: Check package without vignettes on Windows
         if: runner.os == 'Windows'
         uses: r-lib/actions/check-r-package@v2
@@ -109,65 +87,56 @@ jobs:
           build_args: 'c("--no-resave-data","--no-build-vignettes")'
           args: 'c("--as-cran")'
           error-on: '"error"'
-
       - name: Build vignettes on Windows after package installation
         if: runner.os == 'Windows'
         shell: Rscript {0}
         run: |
-          if (!requireNamespace("remotes", quietly = TRUE)) {
-            install.packages("remotes", repos = "https://cloud.r-project.org")
-          }
+          if (!requireNamespace("remotes", quietly = TRUE)) install.packages("remotes", repos = "https://cloud.r-project.org")
+          if (!requireNamespace("tinytex", quietly = TRUE)) install.packages("tinytex", repos = "https://cloud.r-project.org")
+          if (!tinytex::is_tinytex()) tinytex::install_tinytex()
+          tinytex::use_tinytex()
           remotes::install_local(".", build_vignettes = FALSE, upgrade = "never", dependencies = TRUE)
           pkg_path <- find.package("lifecontingencies")
           tools::buildVignettes(dir = pkg_path)
           cat("Built vignettes:\n")
           print(list.files(file.path(pkg_path, "doc"), pattern = "\\.pdf$", full.names = TRUE))
 
-  # Complete matrix: executed after changes reach the default branch, or manually.
   R-CMD-check-full:
     name: full ${{ matrix.config.os }} (${{ matrix.config.r }})
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.config.os }}
-
     strategy:
       fail-fast: false
       matrix:
         config:
-          - { os: ubuntu-latest,  r: 'release' }
-          - { os: ubuntu-latest,  r: 'devel', http-user-agent: 'release' }
+          - { os: ubuntu-latest, r: 'release' }
+          - { os: ubuntu-latest, r: 'devel', http-user-agent: 'release' }
           - { os: windows-latest, r: 'release' }
           - { os: windows-latest, r: 'devel', http-user-agent: 'release' }
-          - { os: macos-latest,  r: 'release' }
-
+          - { os: macos-latest, r: 'release' }
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
       _R_CHECK_CRAN_INCOMING_REMOTE_: false
       _R_CHECK_LIMIT_CORES_: true
       R_CHECK_NUM_CORES: 1
-
     steps:
       - uses: actions/checkout@v5
-
       - name: Use stable Ubuntu mirror for R-devel
         if: runner.os == 'Linux' && matrix.config.r == 'devel'
         shell: bash
-        run: |
-          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.d/* 2>/dev/null || true
-
+        run: sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.d/* 2>/dev/null || true
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
-
       - name: Install system deps (Linux)
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y qpdf ghostscript
-
       - name: Install system deps (macOS)
         if: runner.os == 'macOS'
         run: |
@@ -177,21 +146,14 @@ jobs:
           GETTEXT_LIB="${GETTEXT_PREFIX}/lib"
           test -f "${GETTEXT_INCLUDE}/libintl.h"
           mkdir -p "${HOME}/.R"
-          printf '%s\n' \
-            "CPPFLAGS += -I${GETTEXT_INCLUDE}" \
-            "PKG_CPPFLAGS += -I${GETTEXT_INCLUDE}" \
-            "LDFLAGS += -L${GETTEXT_LIB}" \
-            "PKG_LIBS += -L${GETTEXT_LIB} -lintl" \
-            > "${HOME}/.R/Makevars"
+          printf '%s\n' "CPPFLAGS += -I${GETTEXT_INCLUDE}" "PKG_CPPFLAGS += -I${GETTEXT_INCLUDE}" "LDFLAGS += -L${GETTEXT_LIB}" "PKG_LIBS += -L${GETTEXT_LIB} -lintl" > "${HOME}/.R/Makevars"
           echo "CPPFLAGS=-I${GETTEXT_INCLUDE}" >> "$GITHUB_ENV"
           echo "LDFLAGS=-L${GETTEXT_LIB}" >> "$GITHUB_ENV"
           echo "PKG_CONFIG_PATH=${GETTEXT_LIB}/pkgconfig" >> "$GITHUB_ENV"
-
       - name: Install system deps (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: choco install -y ghostscript qpdf
-
       - name: Install R package dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -202,7 +164,6 @@ jobs:
             any::tinytex
           needs: check
           cache-version: 3
-
       - name: Cache TinyTeX
         id: tinytex-cache
         uses: actions/cache@v4
@@ -212,27 +173,20 @@ jobs:
             ~/Library/TinyTeX
             ~/AppData/Roaming/TinyTeX
           key: tinytex-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/tinytex-packages.txt') }}
-
       - name: Setup TinyTeX
         if: steps.tinytex-cache.outputs.cache-hit != 'true'
         uses: r-lib/actions/setup-tinytex@v2
-
       - name: Restore cached TinyTeX to PATH
         if: steps.tinytex-cache.outputs.cache-hit == 'true'
         shell: Rscript {0}
         run: |
           os <- Sys.info()[["sysname"]]
-          root <- switch(
-            os,
-            Linux = path.expand("~/.TinyTeX"),
-            Darwin = path.expand("~/Library/TinyTeX"),
-            Windows = file.path(Sys.getenv("APPDATA"), "TinyTeX")
-          )
+          root <- switch(os, Linux = path.expand("~/.TinyTeX"), Darwin = path.expand("~/Library/TinyTeX"), Windows = file.path(Sys.getenv("APPDATA"), "TinyTeX"))
+          if (!dir.exists(root) || !file.exists(file.path(root, "bin", "windows", "pdflatex.exe")) && os == "Windows") stop("Cached TinyTeX directory is invalid: ", root)
           if (!dir.exists(root)) stop("Cached TinyTeX directory not found: ", root)
           tinytex::use_tinytex(from = root)
           cat("TinyTeX root:", root, "\n")
           cat("tlmgr:", Sys.which("tlmgr"), "\n")
-
       - name: Install LaTeX packages (TinyTeX)
         shell: Rscript {0}
         run: |
@@ -241,7 +195,6 @@ jobs:
           if (!tinytex::is_tinytex()) stop("TinyTeX is not available")
           tinytex::tlmgr_install(pkgs, .quiet = TRUE)
           cat("Installed/verified", length(pkgs), "LaTeX packages.\n")
-
       - name: Save TinyTeX cache
         if: steps.tinytex-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
@@ -251,7 +204,6 @@ jobs:
             ~/Library/TinyTeX
             ~/AppData/Roaming/TinyTeX
           key: tinytex-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/tinytex-packages.txt') }}
-
       - name: Diagnose TeX installation (Linux)
         if: runner.os == 'Linux'
         shell: Rscript {0}
@@ -261,7 +213,6 @@ jobs:
           cat("xelatex: ", Sys.which("xelatex"), "\n", sep = "")
           cat("tlmgr: ", Sys.which("tlmgr"), "\n", sep = "")
           cat("TinyTeX root: ", tinytex::tinytex_root(), "\n", sep = "")
-
       - name: Install package for vignette build
         shell: Rscript {0}
         run: |
@@ -270,39 +221,29 @@ jobs:
           status <- system2(rbin, c("CMD", "INSTALL", "--no-multiarch", "--no-build-vignettes", "."))
           if (!identical(status, 0L)) stop("R CMD INSTALL failed with status ", status)
           cat("Installed lifecontingencies from source for vignette execution.\n")
-
       - name: Build vignettes
         shell: Rscript {0}
         run: |
           dir.create("inst/doc", recursive = TRUE, showWarnings = FALSE)
           tools::buildVignettes(dir = ".", tangle = FALSE, clean = FALSE)
           outputs <- character()
-          for (dir in c("inst/doc", "doc")) {
-            if (dir.exists(dir)) {
-              outputs <- c(outputs, list.files(dir, full.names = TRUE, recursive = FALSE))
-            }
-          }
+          for (dir in c("inst/doc", "doc")) if (dir.exists(dir)) outputs <- c(outputs, list.files(dir, full.names = TRUE, recursive = FALSE))
           outputs <- unique(outputs)
           if (!length(outputs)) stop("Vignette build produced no output files")
           cat("Vignette outputs:\n")
           print(outputs)
-
       - name: Build source package
         shell: Rscript {0}
         run: |
           os <- Sys.info()[["sysname"]]
           rbin <- file.path(R.home("bin"), if (os == "Windows") "R.exe" else "R")
-          build_args <- c("CMD", "build", ".", "--no-resave-data", "--no-build-vignettes")
-          status <- system2(rbin, build_args)
+          status <- system2(rbin, c("CMD", "build", ".", "--no-resave-data", "--no-build-vignettes"))
           if (!identical(status, 0L)) stop("R CMD build failed with status ", status)
           tarballs <- list.files(pattern = "^lifecontingencies_.*\\.tar\\.gz$", full.names = TRUE)
-          if (length(tarballs) != 1L) {
-            stop("Expected exactly one lifecontingencies source tarball, found: ", paste(tarballs, collapse = ", "))
-          }
+          if (length(tarballs) != 1L) stop("Expected exactly one lifecontingencies source tarball, found: ", paste(tarballs, collapse = ", "))
           tarball <- normalizePath(tarballs[[1]], winslash = "/", mustWork = TRUE)
           cat("Built source package:", tarball, "\n")
           cat("R_SOURCE_TARBALL=", tarball, "\n", sep = "", file = Sys.getenv("GITHUB_ENV"), append = TRUE)
-
       - name: Check built source package
         shell: Rscript {0}
         run: |
@@ -310,7 +251,6 @@ jobs:
           if (!nzchar(tarball) || !file.exists(tarball)) stop("Built source tarball is unavailable: ", tarball)
           result <- rcmdcheck::rcmdcheck(path = tarball, args = "--as-cran", error_on = "error", check_dir = "check")
           print(result)
-
       - name: Upload Linux source package
         if: runner.os == 'Linux' && always()
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Problem
The post-merge CI now fails in the Windows vignette step with `tinytex::use_tinytex(): Please provide a valid path to the TinyTeX directory`. The step builds vignettes after installing the package, but the PR CI did not explicitly initialize TinyTeX for that Windows-only vignette build.

## Fix
Initialize TinyTeX explicitly before installing the package and building the Windows vignettes. If TinyTeX is not available, install it; then register it with `tinytex::use_tinytex()`.

The full-matrix TinyTeX cache restoration is also made defensive on Windows so an invalid cached directory cannot be passed to `use_tinytex()`.

## Scope
CI-only. No package code, tests, or vignette content are changed.