### PR TITLE
fix: make TinyTeX vignette CI robust on all runners

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -14,13 +14,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Fast validation for pull requests: enough to catch most regressions quickly.
 jobs:
   R-CMD-check:
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
     if: github.event_name == 'pull_request'
     runs-on: ${{ matrix.config.os }}
-
     strategy:
       fail-fast: false
       matrix:
@@ -38,31 +36,26 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-
       - name: Use stable Ubuntu mirror for R-devel
         if: runner.os == 'Linux' && matrix.config.r == 'devel'
         shell: bash
         run: |
           sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.d/* 2>/dev/null || true
-
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
-
       - name: Install system deps (Linux)
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y qpdf ghostscript
-
       - name: Install system deps (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: choco install -y ghostscript qpdf
-
       - name: Install R package dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -74,24 +67,13 @@ jobs:
           needs: check
           cache: true
           cache-version: 3
-
       - name: Setup TinyTeX
         uses: r-lib/actions/setup-tinytex@v2
-
       - name: Install LaTeX packages
         shell: Rscript {0}
         run: |
-          pkgs <- c(
-            "pict2e","grfext","everyshi","graphics","etoolbox","kvoptions","xcolor",
-            "collection-latexrecommended","collection-latexextra","collection-fontsrecommended",
-            "ae","inconsolata","upquote","courier","fancyvrb","framed","titling","booktabs",
-            "geometry","hyperref","url","microtype","graphicx","thumbpdf","float","caption",
-            "subcaption","babel-english","amsmath","amssymb","mathtools","siunitx","natbib",
-            "biblatex","csquotes","ulem","parskip","titlesec","wrapfig","longtable","makecell",
-            "multirow","colortbl","pgf","tikz","xkeyval","changepage"
-          )
+          pkgs <- c("pict2e","grfext","everyshi","graphics","etoolbox","kvoptions","xcolor","collection-latexrecommended","collection-latexextra","collection-fontsrecommended","ae","inconsolata","upquote","courier","fancyvrb","framed","titling","booktabs","geometry","hyperref","url","microtype","graphicx","thumbpdf","float","caption","subcaption","babel-english","amsmath","amssymb","mathtools","siunitx","natbib","biblatex","csquotes","ulem","parskip","titlesec","wrapfig","longtable","makecell","multirow","colortbl","pgf","tikz","xkeyval","changepage")
           if (Sys.which("tlmgr") != "") tinytex::tlmgr_install(pkgs, .quiet = TRUE)
-
       - name: Check package
         if: runner.os != 'Windows'
         uses: r-lib/actions/check-r-package@v2
@@ -100,7 +82,6 @@ jobs:
           build_args: 'c("--no-resave-data","--compact-vignettes=both")'
           args: 'c("--as-cran")'
           error-on: '"error"'
-
       - name: Check package without vignettes on Windows
         if: runner.os == 'Windows'
         uses: r-lib/actions/check-r-package@v2
@@ -109,76 +90,32 @@ jobs:
           build_args: 'c("--no-resave-data","--no-build-vignettes")'
           args: 'c("--as-cran")'
           error-on: '"error"'
-
       - name: Build vignettes on Windows after package installation
         if: runner.os == 'Windows'
         shell: Rscript {0}
         run: |
-          if (!requireNamespace("remotes", quietly = TRUE)) {
-            install.packages("remotes", repos = "https://cloud.r-project.org")
-          }
-
-          if (!requireNamespace("tinytex", quietly = TRUE)) {
-            install.packages("tinytex", repos = "https://cloud.r-project.org")
-          }
-
-          # setup-tinytex normally puts TinyTeX on PATH. If it did not,
-          # locate the standard Windows installation explicitly.
-          tinytex_roots <- unique(c(
-            file.path(Sys.getenv("APPDATA"), "TinyTeX"),
-            file.path(Sys.getenv("USERPROFILE"), "AppData", "Roaming", "TinyTeX"),
-            path.expand("~/.TinyTeX")
-          ))
-
-          root <- tinytex_roots[
-            vapply(
-              tinytex_roots,
-              function(x) file.exists(file.path(x, "bin", "windows", "pdflatex.exe")),
-              logical(1)
-            )
-          ]
-
-          if (!length(root)) {
-            root <- file.path(Sys.getenv("APPDATA"), "TinyTeX")
+          if (!requireNamespace("remotes", quietly = TRUE)) install.packages("remotes", repos = "https://cloud.r-project.org")
+          if (!requireNamespace("tinytex", quietly = TRUE)) install.packages("tinytex", repos = "https://cloud.r-project.org")
+          roots <- unique(c(file.path(Sys.getenv("APPDATA"), "TinyTeX"), file.path(Sys.getenv("USERPROFILE"), "AppData", "Roaming", "TinyTeX"), path.expand("~/.TinyTeX")))
+          valid <- roots[vapply(roots, function(x) file.exists(file.path(x, "bin", "windows", "pdflatex.exe")), logical(1))]
+          if (!length(valid)) {
+            root <- roots[[1]]
+            if (dir.exists(root)) unlink(root, recursive = TRUE, force = TRUE)
             tinytex::install_tinytex(dir = root, force = TRUE)
-          } else {
-            root <- root[[1]]
-          }
-
-          root <- normalizePath(root, winslash = "/", mustWork = TRUE)
-          tinytex::use_tinytex(from = root)
-
+            valid <- root
+          } else valid <- valid[[1]]
+          valid <- normalizePath(valid, winslash = "/", mustWork = TRUE)
+          tinytex::use_tinytex(from = valid)
           pdflatex <- Sys.which("pdflatex")
-          if (!nzchar(pdflatex) || !file.exists(pdflatex)) {
-            stop("pdflatex is not available after TinyTeX setup. TinyTeX root: ", root)
-          }
-
-          cat("TinyTeX root: ", root, "\n", sep = "")
-          cat("pdflatex: ", pdflatex, "\n", sep = "")
-          cat("tlmgr: ", Sys.which("tlmgr"), "\n", sep = "")
-
-          remotes::install_local(
-            ".",
-            build_vignettes = FALSE,
-            upgrade = "never",
-            dependencies = TRUE
-          )
-
+          if (!nzchar(pdflatex) || !file.exists(pdflatex)) stop("pdflatex is not available after TinyTeX setup. Root: ", valid)
+          remotes::install_local(".", build_vignettes = FALSE, upgrade = "never", dependencies = TRUE)
           pkg_path <- find.package("lifecontingencies")
           tools::buildVignettes(dir = pkg_path)
-          cat("Built vignettes:\n")
-          print(list.files(
-            file.path(pkg_path, "doc"),
-            pattern = "\\.pdf$",
-            full.names = TRUE
-          ))
 
-  # Complete matrix: executed after changes reach the default branch, or manually.
   R-CMD-check-full:
     name: full ${{ matrix.config.os }} (${{ matrix.config.r }})
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.config.os }}
-
     strategy:
       fail-fast: false
       matrix:
@@ -198,26 +135,22 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-
       - name: Use stable Ubuntu mirror for R-devel
         if: runner.os == 'Linux' && matrix.config.r == 'devel'
         shell: bash
         run: |
           sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.d/* 2>/dev/null || true
-
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
-
       - name: Install system deps (Linux)
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y qpdf ghostscript
-
       - name: Install system deps (macOS)
         if: runner.os == 'macOS'
         run: |
@@ -227,21 +160,14 @@ jobs:
           GETTEXT_LIB="${GETTEXT_PREFIX}/lib"
           test -f "${GETTEXT_INCLUDE}/libintl.h"
           mkdir -p "${HOME}/.R"
-          printf '%s\n' \
-            "CPPFLAGS += -I${GETTEXT_INCLUDE}" \
-            "PKG_CPPFLAGS += -I${GETTEXT_INCLUDE}" \
-            "LDFLAGS += -L${GETTEXT_LIB}" \
-            "PKG_LIBS += -L${GETTEXT_LIB} -lintl" \
-            > "${HOME}/.R/Makevars"
+          printf '%s\n' "CPPFLAGS += -I${GETTEXT_INCLUDE}" "PKG_CPPFLAGS += -I${GETTEXT_INCLUDE}" "LDFLAGS += -L${GETTEXT_LIB}" "PKG_LIBS += -L${GETTEXT_LIB} -lintl" > "${HOME}/.R/Makevars"
           echo "CPPFLAGS=-I${GETTEXT_INCLUDE}" >> "$GITHUB_ENV"
           echo "LDFLAGS=-L${GETTEXT_LIB}" >> "$GITHUB_ENV"
           echo "PKG_CONFIG_PATH=${GETTEXT_LIB}/pkgconfig" >> "$GITHUB_ENV"
-
       - name: Install system deps (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: choco install -y ghostscript qpdf
-
       - name: Install R package dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -252,7 +178,6 @@ jobs:
             any::tinytex
           needs: check
           cache-version: 3
-
       - name: Cache TinyTeX
         id: tinytex-cache
         uses: actions/cache@v4
@@ -261,28 +186,38 @@ jobs:
             ~/.TinyTeX
             ~/Library/TinyTeX
             ~/AppData/Roaming/TinyTeX
-          key: tinytex-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/tinytex-packages.txt') }}
-
+          key: tinytex-v3-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/tinytex-packages.txt') }}
       - name: Setup TinyTeX
         if: steps.tinytex-cache.outputs.cache-hit != 'true'
         uses: r-lib/actions/setup-tinytex@v2
-
       - name: Restore cached TinyTeX to PATH
         if: steps.tinytex-cache.outputs.cache-hit == 'true'
         shell: Rscript {0}
         run: |
           os <- Sys.info()[["sysname"]]
-          root <- switch(
-            os,
-            Linux = path.expand("~/.TinyTeX"),
-            Darwin = path.expand("~/Library/TinyTeX"),
-            Windows = file.path(Sys.getenv("APPDATA"), "TinyTeX")
-          )
+          root <- switch(os, Linux = path.expand("~/.TinyTeX"), Darwin = path.expand("~/Library/TinyTeX"), Windows = file.path(Sys.getenv("APPDATA"), "TinyTeX"))
           if (!dir.exists(root)) stop("Cached TinyTeX directory not found: ", root)
           tinytex::use_tinytex(from = root)
-          cat("TinyTeX root:", root, "\n")
-          cat("tlmgr:", Sys.which("tlmgr"), "\n")
-
+      - name: Ensure TinyTeX and pdflatex are available
+        shell: Rscript {0}
+        run: |
+          if (!requireNamespace("tinytex", quietly = TRUE)) install.packages("tinytex", repos = "https://cloud.r-project.org")
+          os <- Sys.info()[["sysname"]]
+          roots <- switch(os, Linux = path.expand("~/.TinyTeX"), Darwin = path.expand("~/Library/TinyTeX"), Windows = unique(c(file.path(Sys.getenv("APPDATA"), "TinyTeX"), file.path(Sys.getenv("USERPROFILE"), "AppData", "Roaming", "TinyTeX"), path.expand("~/.TinyTeX"))))
+          valid <- roots[vapply(roots, function(x) if (os == "Windows") file.exists(file.path(x, "bin", "windows", "pdflatex.exe")) else dir.exists(x) && file.exists(Sys.which("pdflatex")), logical(1))]
+          if (!length(valid) || !nzchar(Sys.which("pdflatex"))) {
+            root <- roots[[1]]
+            if (dir.exists(root)) unlink(root, recursive = TRUE, force = TRUE)
+            tinytex::install_tinytex(dir = root, force = TRUE)
+            valid <- root
+          } else valid <- valid[[1]]
+          valid <- normalizePath(valid, winslash = "/", mustWork = TRUE)
+          tinytex::use_tinytex(from = valid)
+          pdflatex <- Sys.which("pdflatex")
+          if (!nzchar(pdflatex) || !file.exists(pdflatex)) stop("pdflatex is not available after TinyTeX bootstrap. Root: ", valid)
+          cat("TinyTeX root: ", valid, "\n", sep = "")
+          cat("pdflatex: ", pdflatex, "\n", sep = "")
+          cat("tlmgr: ", Sys.which("tlmgr"), "\n", sep = "")
       - name: Install LaTeX packages (TinyTeX)
         shell: Rscript {0}
         run: |
@@ -290,8 +225,6 @@ jobs:
           pkgs <- pkgs[nzchar(pkgs) & !startsWith(pkgs, "#")]
           if (!tinytex::is_tinytex()) stop("TinyTeX is not available")
           tinytex::tlmgr_install(pkgs, .quiet = TRUE)
-          cat("Installed/verified", length(pkgs), "LaTeX packages.\n")
-
       - name: Save TinyTeX cache
         if: steps.tinytex-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
@@ -300,10 +233,8 @@ jobs:
             ~/.TinyTeX
             ~/Library/TinyTeX
             ~/AppData/Roaming/TinyTeX
-          key: tinytex-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/tinytex-packages.txt') }}
-
-      - name: Diagnose TeX installation (Linux)
-        if: runner.os == 'Linux'
+          key: tinytex-v3-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/tinytex-packages.txt') }}
+      - name: Diagnose TeX installation
         shell: Rscript {0}
         run: |
           cat("R: ", R.version.string, "\n", sep = "")
@@ -311,7 +242,6 @@ jobs:
           cat("xelatex: ", Sys.which("xelatex"), "\n", sep = "")
           cat("tlmgr: ", Sys.which("tlmgr"), "\n", sep = "")
           cat("TinyTeX root: ", tinytex::tinytex_root(), "\n", sep = "")
-
       - name: Install package for vignette build
         shell: Rscript {0}
         run: |
@@ -319,40 +249,28 @@ jobs:
           rbin <- file.path(R.home("bin"), if (os == "Windows") "R.exe" else "R")
           status <- system2(rbin, c("CMD", "INSTALL", "--no-multiarch", "--no-build-vignettes", "."))
           if (!identical(status, 0L)) stop("R CMD INSTALL failed with status ", status)
-          cat("Installed lifecontingencies from source for vignette execution.\n")
-
       - name: Build vignettes
         shell: Rscript {0}
         run: |
+          pdflatex <- Sys.which("pdflatex")
+          if (!nzchar(pdflatex) || !file.exists(pdflatex)) stop("pdflatex is unavailable at vignette build time")
           dir.create("inst/doc", recursive = TRUE, showWarnings = FALSE)
           tools::buildVignettes(dir = ".", tangle = FALSE, clean = FALSE)
-          outputs <- character()
-          for (dir in c("inst/doc", "doc")) {
-            if (dir.exists(dir)) {
-              outputs <- c(outputs, list.files(dir, full.names = TRUE, recursive = FALSE))
-            }
-          }
-          outputs <- unique(outputs)
+          outputs <- unique(unlist(lapply(c("inst/doc", "doc"), function(dir) if (dir.exists(dir)) list.files(dir, full.names = TRUE, recursive = FALSE) else character())))
           if (!length(outputs)) stop("Vignette build produced no output files")
           cat("Vignette outputs:\n")
           print(outputs)
-
       - name: Build source package
         shell: Rscript {0}
         run: |
           os <- Sys.info()[["sysname"]]
           rbin <- file.path(R.home("bin"), if (os == "Windows") "R.exe" else "R")
-          build_args <- c("CMD", "build", ".", "--no-resave-data", "--no-build-vignettes")
-          status <- system2(rbin, build_args)
+          status <- system2(rbin, c("CMD", "build", ".", "--no-resave-data", "--no-build-vignettes"))
           if (!identical(status, 0L)) stop("R CMD build failed with status ", status)
           tarballs <- list.files(pattern = "^lifecontingencies_.*\\.tar\\.gz$", full.names = TRUE)
-          if (length(tarballs) != 1L) {
-            stop("Expected exactly one lifecontingencies source tarball, found: ", paste(tarballs, collapse = ", "))
-          }
+          if (length(tarballs) != 1L) stop("Expected exactly one lifecontingencies source tarball, found: ", paste(tarballs, collapse = ", "))
           tarball <- normalizePath(tarballs[[1]], winslash = "/", mustWork = TRUE)
-          cat("Built source package:", tarball, "\n")
           cat("R_SOURCE_TARBALL=", tarball, "\n", sep = "", file = Sys.getenv("GITHUB_ENV"), append = TRUE)
-
       - name: Check built source package
         shell: Rscript {0}
         run: |
@@ -360,7 +278,6 @@ jobs:
           if (!nzchar(tarball) || !file.exists(tarball)) stop("Built source tarball is unavailable: ", tarball)
           result <- rcmdcheck::rcmdcheck(path = tarball, args = "--as-cran", error_on = "error", check_dir = "check")
           print(result)
-
       - name: Upload Linux source package
         if: runner.os == 'Linux' && always()
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## What this fixes

The full `R-CMD-check` job can reach `tools::buildVignettes()` with a TinyTeX directory present but `pdflatex` unavailable, causing the `.Rnw` vignettes to fail with `pdflatex is not available`.

This PR:
- invalidates the existing TinyTeX cache key;
- explicitly bootstraps TinyTeX when the cached installation is incomplete;
- calls `tinytex::use_tinytex()` after setup/restore;
- verifies `pdflatex` immediately before package installation and vignette building;
- keeps the existing Windows-specific defensive setup from PR #64.

The goal is to make vignette compilation independent of a stale cache or PATH state.