### PR TITLE
Fix vignette warnings from autoplot.lifetable

### DIFF
--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -22,7 +22,7 @@ autoplot.lifetable <- function(object, ...) {
 
   ggplot2::ggplot(
     data,
-    ggplot2::aes(x = data[["x"]], y = data[["lx"]])
+    ggplot2::aes(x = .data[["x"]], y = .data[["lx"]])
   ) +
     ggplot2::geom_line(...) +
     ggplot2::labs(


### PR DESCRIPTION
## Summary
- replace deprecated `data[[...]]` accesses inside `ggplot2::aes()` with the tidy-evaluation `.data[[...]]` pronoun
- eliminate the warnings emitted while rebuilding `an_introduction_to_lifecontingencies_package.Rnw`

## Scope
This is a minimal documentation/build-warning fix in `R/autoplot.R`; no actuarial calculations or public API behavior are changed.

The other vignette rebuilds shown in the reported output complete successfully.