### PR TITLE
fix: validate vignette regeneration in CI

### DIFF
--- a/.github/scripts/check-vignettes.R
+++ b/.github/scripts/check-vignettes.R
@@ -1,0 +1,24 @@
+vignettes <- list.files(
+  "vignettes",
+  pattern = "\\.(Rnw|Rmd)$",
+  full.names = TRUE,
+  recursive = FALSE
+)
+
+if (!length(vignettes)) {
+  stop("No vignette source files found in vignettes/")
+}
+
+message("Building vignettes:")
+print(vignettes)
+
+status <- tools::buildVignettes(
+  dir = ".",
+  tangle = FALSE,
+  check = TRUE,
+  quiet = FALSE
+)
+
+if (!isTRUE(status)) {
+  stop("Vignette build/check failed")
+}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -153,6 +153,12 @@ jobs:
             quiet = FALSE
           )
 
+      - name: Validate vignette sources explicitly
+        if: runner.os == 'ubuntu-latest' && matrix.config.r == 'release'
+        shell: Rscript {0}
+        run: |
+          source(".github/scripts/check-vignettes.R")
+
   R-CMD-check-full:
     if: >-
       github.event_name == 'push' &&


### PR DESCRIPTION
## Summary
- add an explicit CI validation step for vignette source regeneration on Ubuntu/release
- fail CI when `tools::buildVignettes()` cannot rebuild/check the `.Rnw` and `.Rmd` vignette sources
- keep the existing TinyTeX/pdflatex setup and `--compact-vignettes=both` R CMD check path unchanged

## Important note on the `.data` warning
`autoplot.lifetable()` is already fixed in PR #70 (and was previously fixed by merged PR #69), but that change is not on the current `master` base used by this branch. The warning therefore remains on master until #70 is merged.

The log shown for the vignette rebuild itself does not contain a LaTeX failure: the `.Rnw` and `.Rmd` sources shown complete their rebuild successfully. This PR makes that success/failure explicit in CI rather than treating the raw rebuild log as an ambiguous signal.
