### PR TITLE
fix: remove R CMD check NOTE from autoplot

### DIFF
--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -22,7 +22,7 @@ autoplot.lifetable <- function(object, ...) {
 
   ggplot2::ggplot(
     data,
-    ggplot2::aes(x = .data[["x"]], y = .data[["lx"]])
+    ggplot2::aes(x = data$x, y = data$lx)
   ) +
     ggplot2::geom_line(...) +
     ggplot2::labs(


### PR DESCRIPTION
## Summary
- avoid the `.data` pronoun in `autoplot.lifetable()` that triggers an R CMD check NOTE
- keep the plotting behaviour unchanged

## Check
The reported NOTE was:
`autoplot.lifetable: no visible binding for global variable '.data'`

This PR removes that NOTE without adding a new package dependency.

The separate warning about `--compact-vignettes=both` is an R 4.6.1/local check-option issue and is not caused by package code.